### PR TITLE
ci: add auto-labeler for PRs and issues

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -61,11 +61,13 @@ jobs:
               if (error.status === 422) {
                 const safe = labels.filter(l => l.startsWith('type:'));
                 if (safe.length > 0) {
-                  await github.rest.issues.addLabels({
-                    ...context.repo,
-                    issue_number: context.issue.number,
-                    labels: safe,
-                  });
+                  try {
+                    await github.rest.issues.addLabels({
+                      ...context.repo,
+                      issue_number: context.issue.number,
+                      labels: safe,
+                    });
+                  } catch { /* all type: labels exist — ignore */ }
                 }
               } else {
                 throw error;
@@ -107,8 +109,25 @@ jobs:
               }
             }
 
-            await github.rest.issues.addLabels({
-              ...context.repo,
-              issue_number: context.issue.number,
-              labels,
-            });
+            try {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: context.issue.number,
+                labels,
+              });
+            } catch (error) {
+              if (error.status === 422) {
+                const safe = labels.filter(l => l.startsWith('type:') || l === 'status:triage');
+                if (safe.length > 0) {
+                  try {
+                    await github.rest.issues.addLabels({
+                      ...context.repo,
+                      issue_number: context.issue.number,
+                      labels: safe,
+                    });
+                  } catch { /* labels don't exist — ignore */ }
+                }
+              } else {
+                throw error;
+              }
+            }


### PR DESCRIPTION
## Summary

- Add `auto-label.yml` workflow that labels PRs (type from conventional commit prefix, breaking change) and issues (status:triage + type detection)
- Package label step skipped (no `labeler.yml` in examples repo)

## Test plan

- [ ] Create test issue → expect `status:triage`
- [ ] Next PR with conventional commit prefix → expect type label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic labeling for pull requests and issues based on titles and content.
  * Detects breaking changes and applies appropriate labels.
  * Adds triage status labeling for new issues.
  * Applies package-related labels when repository configuration is present.
  * Falls back to a safe subset of labels if some labels cannot be applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->