### PR TITLE
fix(cross-runtime-test): add buf:generate script for consistency

### DIFF
--- a/cross-runtime-test/package.json
+++ b/cross-runtime-test/package.json
@@ -9,7 +9,8 @@
     "#*": "./src/*"
   },
   "scripts": {
-    "build:proto": "buf generate",
+    "buf:generate": "buf generate",
+    "build:proto": "pnpm run buf:generate",
     "test": "node --test tests/**/*.test.ts",
     "test:node": "node --test tests/**/*.test.ts",
     "test:bun": "bun test tests/",


### PR DESCRIPTION
## Summary

Added missing `buf:generate` script to `cross-runtime-test/package.json`. All other proto-using examples have both `buf:generate` and `build:proto`, but this example only had `build:proto`, causing `pnpm run buf:generate` to fail during L4 test-pack pipeline.

## Test plan

- [x] `pnpm run buf:generate` works
- [x] `pnpm run build:proto` still works (delegates to buf:generate)
- [x] 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)