### PR TITLE
chore(deps): bump @connectum/* to 1.0.0-rc.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ See [runn/README.md](runn/README.md) for details.
 
 ## Dependencies
 
-All examples use published `@connectum/*` packages from npm (currently `1.0.0-rc.6`). Just `pnpm install` in any example directory to get started.
+All examples use published `@connectum/*` packages from npm (currently `1.0.0-rc.10`). Just `pnpm install` in any example directory to get started.
 
 ## License
 

--- a/auth/package.json
+++ b/auth/package.json
@@ -27,11 +27,11 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/auth": "1.0.0-rc.7",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/auth": "1.0.0-rc.10",
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/basic-service-bun/package.json
+++ b/basic-service-bun/package.json
@@ -24,10 +24,10 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/basic-service-node/package.json
+++ b/basic-service-node/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/basic-service-tsx/package.json
+++ b/basic-service-tsx/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/cross-runtime-test/README.md
+++ b/cross-runtime-test/README.md
@@ -73,10 +73,10 @@ pnpm test
 
 ## Package Versions
 
-Currently configured for `1.0.0-rc.4`. Update versions in `package.json` after publishing new compiled releases.
+Currently configured for `1.0.0-rc.10`. Update versions in `package.json` after publishing new compiled releases.
 
 ## Important Notes
 
-- The current `1.0.0-rc.4` on npm publishes raw `.ts` source files, which Node.js cannot type-strip from `node_modules`. Tests will only pass with compiled tarballs or a future npm release that includes `dist/`.
+- Starting with `1.0.0-rc.8`, npm publishes compiled `dist/` artifacts (ESM `.js` + `.d.ts` + source maps) via tsup, so cross-runtime tests work directly against published versions without tarballs.
 - Each test creates its own server on port 0 (random) and uses `createHealthcheckManager()` to avoid shared state between tests.
 - Health check tests use raw HTTP/2 client (`node:http2`) since the server runs on HTTP/2 plaintext.

--- a/cross-runtime-test/package.json
+++ b/cross-runtime-test/package.json
@@ -23,10 +23,10 @@
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-node": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/o11y-coroot/service/package.json
+++ b/o11y-coroot/service/package.json
@@ -25,11 +25,11 @@
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-node": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/otel": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/otel": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/performance-test-server/package.json
+++ b/performance-test-server/package.json
@@ -30,9 +30,9 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/otel": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/otel": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/runn/package.json
+++ b/runn/package.json
@@ -27,12 +27,12 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/auth": "1.0.0-rc.7",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/otel": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7",
+    "@connectum/auth": "1.0.0-rc.10",
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/otel": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10",
     "jose": "^6.0.11"
   },
   "devDependencies": {

--- a/with-custom-interceptor/package.json
+++ b/with-custom-interceptor/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/with-events-amqp/package.json
+++ b/with-events-amqp/package.json
@@ -29,12 +29,12 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/events": "1.0.0-rc.7",
-    "@connectum/events-amqp": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/events": "1.0.0-rc.10",
+    "@connectum/events-amqp": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/with-events-dlq/package.json
+++ b/with-events-dlq/package.json
@@ -29,12 +29,12 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/events": "1.0.0-rc.7",
-    "@connectum/events-nats": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/events": "1.0.0-rc.10",
+    "@connectum/events-nats": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/with-events-kafka/package.json
+++ b/with-events-kafka/package.json
@@ -29,12 +29,12 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/events": "1.0.0-rc.7",
-    "@connectum/events-kafka": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/events": "1.0.0-rc.10",
+    "@connectum/events-kafka": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/with-events-nats/package.json
+++ b/with-events-nats/package.json
@@ -29,12 +29,12 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/events": "1.0.0-rc.7",
-    "@connectum/events-nats": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/events": "1.0.0-rc.10",
+    "@connectum/events-nats": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/with-events-redpanda/package.json
+++ b/with-events-redpanda/package.json
@@ -29,12 +29,12 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/events": "1.0.0-rc.7",
-    "@connectum/events-kafka": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/events": "1.0.0-rc.10",
+    "@connectum/events-kafka": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",

--- a/with-events-valkey/package.json
+++ b/with-events-valkey/package.json
@@ -26,12 +26,12 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.11.0",
     "@connectrpc/connect": "^2.1.1",
-    "@connectum/core": "1.0.0-rc.7",
-    "@connectum/events": "1.0.0-rc.7",
-    "@connectum/events-redis": "1.0.0-rc.7",
-    "@connectum/healthcheck": "1.0.0-rc.7",
-    "@connectum/interceptors": "1.0.0-rc.7",
-    "@connectum/reflection": "1.0.0-rc.7"
+    "@connectum/core": "1.0.0-rc.10",
+    "@connectum/events": "1.0.0-rc.10",
+    "@connectum/events-redis": "1.0.0-rc.10",
+    "@connectum/healthcheck": "1.0.0-rc.10",
+    "@connectum/interceptors": "1.0.0-rc.10",
+    "@connectum/reflection": "1.0.0-rc.10"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",


### PR DESCRIPTION
## Summary
- Bumps all @connectum/* dependencies across 15 examples from 1.0.0-rc.7 to 1.0.0-rc.10
- Examples were 3 release candidates behind current framework state (fixed versioning for all @connectum/* packages)
- Updates README.md mentioning rc.6 to current version
- Fixes cross-runtime-test/README.md — replaces outdated note about raw .ts npm distribution with correct tsup-compiled dist/ description (applies from rc.8+)

## Changed examples
basic-service-{node,bun,tsx}, auth, with-custom-interceptor, with-events-{nats,kafka,redpanda,valkey,amqp,dlq}, runn, o11y-coroot/service, performance-test-server, cross-runtime-test

## Test plan
- [ ] `pnpm install` succeeds in each example directory
- [ ] `CONNECTUM_LOCAL=1 pnpm install` works with local tarballs from pack/
- [ ] Smoke-test at least one example per category (basic, auth, events-*, observability)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded all package dependencies to version 1.0.0-rc.10.

* **Documentation**
  * Updated version references to 1.0.0-rc.10 and clarified that compiled artifacts are now included in published releases, enabling direct usage without additional build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->