### PR TITLE
security(deps): resolve 6 critical Dependabot alerts (protobufjs RCE)

### DIFF
--- a/o11y-coroot/service/package.json
+++ b/o11y-coroot/service/package.json
@@ -36,5 +36,11 @@
     "@bufbuild/protoc-gen-es": "^2.11.0",
     "@types/node": "^25.2.0",
     "typescript": "^5.9.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "protobufjs@<7.5.5": "7.5.5",
+      "protobufjs@>=8.0.0 <8.0.1": "8.0.1"
+    }
   }
 }

--- a/performance-test-server/package.json
+++ b/performance-test-server/package.json
@@ -44,6 +44,10 @@
     "onlyBuiltDependencies": [
       "@bufbuild/buf",
       "protobufjs"
-    ]
+    ],
+    "overrides": {
+      "protobufjs@<7.5.5": "7.5.5",
+      "protobufjs@>=8.0.0 <8.0.1": "8.0.1"
+    }
   }
 }

--- a/runn/package.json
+++ b/runn/package.json
@@ -44,6 +44,10 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "@bufbuild/buf"
-    ]
+    ],
+    "overrides": {
+      "protobufjs@<7.5.5": "7.5.5",
+      "protobufjs@>=8.0.0 <8.0.1": "8.0.1"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Resolves all critical-severity Dependabot alerts on `main`. All six alerts are the same advisory (**GHSA-xq3m-2v4x-88gg / CVE-2026-41242** — *Arbitrary code execution in protobufjs*) hitting two transitive version ranges across three examples.

| # | Package | Vulnerable | Patched | Type | Pulled via | Affected examples |
|---|---------|------------|---------|------|------------|-------------------|
| 4, 5, 6 | `protobufjs` | `< 7.5.5` (was `7.5.4`) | `7.5.5` | transitive | `@grpc/proto-loader` | `runn`, `performance-test-server`, `o11y-coroot/service` |
| 1, 2, 3 | `protobufjs` | `>= 8.0.0 < 8.0.1` (was `8.0.0`) | `8.0.1` | transitive | `@opentelemetry/otlp-transformer` | `runn`, `performance-test-server`, `o11y-coroot/service` |

Advisory: https://github.com/advisories/GHSA-xq3m-2v4x-88gg

## Mitigation strategy

`protobufjs` is **not a direct dependency** of any example — it is pulled transitively. Since each example is a stand-alone project (no root `pnpm-workspace.yaml`), the fix is applied per example via `pnpm.overrides` in its own `package.json`.

Range-specific selectors are used so only the vulnerable versions are forced to their minimum patched release — the rest of the dependency tree stays intact (no major bumps of `@grpc/proto-loader`, `@opentelemetry/*`, or peer packages):

```json
"pnpm": {
  "overrides": {
    "protobufjs@<7.5.5": "7.5.5",
    "protobufjs@>=8.0.0 <8.0.1": "8.0.1"
  }
}
```

Both patched versions are patch-level (7.5.4 → 7.5.5, 8.0.0 → 8.0.1) — no breaking changes per the [protobufjs changelog](https://github.com/protobufjs/protobuf.js/releases).

Lockfiles are intentionally left untouched in this PR; they will be regenerated by CI / developers on the next `pnpm install` in each affected example.

## Files changed

- `runn/package.json` — added `pnpm.overrides`
- `performance-test-server/package.json` — added `pnpm.overrides`
- `o11y-coroot/service/package.json` — added `pnpm.overrides` block

## Test plan

- [ ] CI passes for all affected examples (`CONNECTUM_LOCAL=1 pnpm install` + smoke test)
- [ ] After merge, `pnpm install` in each affected example regenerates lockfiles with `protobufjs@7.5.5` and `protobufjs@8.0.1`
- [ ] No remaining open critical Dependabot alerts on `main` after merge (automatic re-scan)
- [ ] Changelog of upgraded packages reviewed for breaking changes — confirmed patch-only