### PR TITLE
docs(examples): align with opt-in resilience defaults

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -90,7 +90,7 @@ Both services expose three RPC methods with the same authorization levels:
 Request
   │
   ▼
-defaultInterceptors     (error handler, timeout, bulkhead)
+defaultInterceptors     (error handler, validation)
   │
   ▼
 jwtAuth                 (extract + verify JWT, set AuthContext)

--- a/basic-service-bun/README.md
+++ b/basic-service-bun/README.md
@@ -8,7 +8,7 @@ Demonstrates:
 - Greeter service with two RPC methods
 - Health checks (gRPC + HTTP) via `@connectum/healthcheck`
 - Server reflection via `@connectum/reflection`
-- Default interceptors (error handler, timeout, bulkhead) via `@connectum/interceptors`
+- Default interceptors (error handler, validation) via `@connectum/interceptors`
 - Graceful shutdown
 
 ## Prerequisites

--- a/basic-service-bun/src/index.ts
+++ b/basic-service-bun/src/index.ts
@@ -24,7 +24,8 @@ console.log("🚀 Starting Basic Service Example...\n");
  *
  * Interceptors are passed explicitly — core has no built-in interceptors.
  * Use createDefaultInterceptors() from @connectum/interceptors for the
- * production-ready chain (error handler, timeout, bulkhead, etc.).
+ * default chain (error handler + validation; resilience interceptors
+ * such as timeout, bulkhead, circuitBreaker, retry are opt-in).
  */
 const options: CreateServerOptions = {
     // Register services

--- a/basic-service-node/README.md
+++ b/basic-service-node/README.md
@@ -8,7 +8,7 @@ Demonstrates:
 - Greeter service with two RPC methods
 - Health checks (gRPC + HTTP) via `@connectum/healthcheck`
 - Server reflection via `@connectum/reflection`
-- Default interceptors (error handler, timeout, bulkhead) via `@connectum/interceptors`
+- Default interceptors (error handler, validation) via `@connectum/interceptors`
 - Graceful shutdown
 
 ## Prerequisites

--- a/basic-service-node/src/index.ts
+++ b/basic-service-node/src/index.ts
@@ -24,7 +24,8 @@ console.log("🚀 Starting Basic Service Example...\n");
  *
  * Interceptors are passed explicitly — core has no built-in interceptors.
  * Use createDefaultInterceptors() from @connectum/interceptors for the
- * production-ready chain (error handler, timeout, bulkhead, etc.).
+ * default chain (error handler + validation; resilience interceptors
+ * such as timeout, bulkhead, circuitBreaker, retry are opt-in).
  */
 const options: CreateServerOptions = {
     // Register services

--- a/basic-service-tsx/README.md
+++ b/basic-service-tsx/README.md
@@ -8,7 +8,7 @@ Demonstrates:
 - Greeter service with two RPC methods
 - Health checks (gRPC + HTTP) via `@connectum/healthcheck`
 - Server reflection via `@connectum/reflection`
-- Default interceptors (error handler, timeout, bulkhead) via `@connectum/interceptors`
+- Default interceptors (error handler, validation) via `@connectum/interceptors`
 - Graceful shutdown
 
 ## Prerequisites

--- a/basic-service-tsx/src/index.ts
+++ b/basic-service-tsx/src/index.ts
@@ -24,7 +24,8 @@ console.log("🚀 Starting Basic Service Example...\n");
  *
  * Interceptors are passed explicitly — core has no built-in interceptors.
  * Use createDefaultInterceptors() from @connectum/interceptors for the
- * production-ready chain (error handler, timeout, bulkhead, etc.).
+ * default chain (error handler + validation; resilience interceptors
+ * such as timeout, bulkhead, circuitBreaker, retry are opt-in).
  */
 const options: CreateServerOptions = {
     // Register services

--- a/performance-test-server/README.md
+++ b/performance-test-server/README.md
@@ -174,14 +174,10 @@ interceptors: [] // NO interceptors - pure baseline
 ### Validation Only (Port 8082)
 
 ```typescript
+// Validation is enabled by default; resilience interceptors are opt-in,
+// so only errorHandler needs to be disabled explicitly.
 interceptors: createDefaultInterceptors({
   errorHandler: false,
-  timeout: false,
-  bulkhead: false,
-  circuitBreaker: false,
-  retry: false,
-  validation: true,
-  serializer: false,
 })
 ```
 
@@ -212,8 +208,13 @@ interceptors: [
 interceptors: [
   ...createDefaultInterceptors({
     errorHandler: { logErrors: true, includeStackTrace: true },
+    // Resilience interceptors are opt-in — enabled explicitly here
+    // so this configuration measures the full chain overhead.
+    timeout: true,
+    bulkhead: true,
+    circuitBreaker: true,
+    retry: true,
     serializer: true,
-    validation: true,
   }),
   createLoggerInterceptor({ level: "error", skipHealthCheck: true }),
   createOtelInterceptor({

--- a/performance-test-server/src/index.ts
+++ b/performance-test-server/src/index.ts
@@ -52,14 +52,10 @@ const validationOptions: CreateServerOptions = {
     port: 8082,
     host: "0.0.0.0",
     tls: tlsConfig,
+    // Validation is enabled by default; resilience interceptors are opt-in,
+    // so only errorHandler needs to be disabled explicitly.
     interceptors: createDefaultInterceptors({
         errorHandler: false,
-        timeout: false,
-        bulkhead: false,
-        circuitBreaker: false,
-        retry: false,
-        validation: true,
-        serializer: false,
     }),
 };
 
@@ -111,8 +107,13 @@ const fullChainOptions: CreateServerOptions = {
                 logErrors: true,
                 includeStackTrace: true,
             },
+            // Resilience interceptors are opt-in — enable them explicitly
+            // so this configuration measures the full chain overhead.
+            timeout: true,
+            bulkhead: true,
+            circuitBreaker: true,
+            retry: true,
             serializer: true,
-            validation: true,
         }),
         createLoggerInterceptor({
             level: "error",

--- a/with-custom-interceptor/src/index.ts
+++ b/with-custom-interceptor/src/index.ts
@@ -19,7 +19,7 @@ console.log("Starting Custom Interceptor Example...\n");
  * Create server with custom interceptors appended after the default chain.
  *
  * Interceptor execution order:
- * 1. Default chain (errorHandler, timeout, bulkhead, circuitBreaker, retry, fallback, serializer)
+ * 1. Default chain (errorHandler, validation; resilience interceptors are opt-in)
  * 2. apiKeyInterceptor  — checks x-api-key for SecureEcho
  * 3. rateLimitInterceptor — rate-limits RateLimitedEcho
  */


### PR DESCRIPTION
Aligns example READMEs and comments with connectum#133 (resilience interceptors now opt-in in createDefaultInterceptors).

> Pairs with connectum#133. Stacked on examples#18; retargets to main after #18 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)