### PR TITLE
docs(examples): align READMEs with 1.0.0; fix car-sharing chain order

### DIFF
--- a/car-sharing/Dockerfile
+++ b/car-sharing/Dockerfile
@@ -7,9 +7,10 @@
 FROM node:25-slim AS deps
 RUN npm install -g pnpm
 WORKDIR /app
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-# The committed lockfile already resolves @connectum/* to published versions.
-RUN pnpm install --frozen-lockfile --prod
+COPY package.json pnpm-workspace.yaml ./
+# No lockfile is committed for this example; pnpm resolves @connectum/* to the
+# published 1.0.0 versions pinned in package.json and writes a lockfile here.
+RUN pnpm install --prod
 
 # ── runtime: copy deps + source + generated proto code ──────────────────────
 FROM node:25-slim AS runtime

--- a/car-sharing/README.md
+++ b/car-sharing/README.md
@@ -5,7 +5,7 @@ Connectum image runs as three microservices on Kubernetes behind an Istio mesh,
 showing three things that are normally hard, wired straight from the framework:
 
 - **Gateway auth at the edge** — JWT authentication + proto-driven authorization
-  (`@connectum/auth`) on the public `trips` service.
+  (`@connectum/auth`) on the public-facing `trips` service.
 - **Cross-service `ctx.call` across split pods** — the trip handler calls fleet
   and billing through the typed service catalog; the framework picks in-process
   or network transport from env, no handler changes.
@@ -133,6 +133,9 @@ pnpm run docker:build    # docker build -t car-sharing:local .
 
 The Dockerfile is multi-stage and role-agnostic: `node src/index.ts` is the
 entrypoint for every role (engines.node `>=25.2.0` runs TypeScript natively).
+No lockfile is committed for this example; the `deps` stage runs `pnpm install`,
+which resolves `@connectum/*` to the published 1.0.0 versions pinned in
+`package.json` and generates the lockfile inside the image.
 
 ## Deploy to Kubernetes + Istio
 

--- a/car-sharing/src/server.ts
+++ b/car-sharing/src/server.ts
@@ -5,9 +5,10 @@
  * What stays constant across topologies:
  *  - the same three service definitions are passed to `createServer`;
  *  - the same generated `serviceCatalog` types and routes every `ctx.call`;
- *  - the same gateway interceptor chain (default → OTel → JWT auth → proto
- *    authz). The chain is uniform; per-method behaviour comes from proto
- *    annotations (fleet/billing are `public`, TripService requires auth).
+ *  - the same gateway interceptor chain in ADR-024 order (errorHandler → JWT
+ *    auth → proto authz → OTel → validation). The chain is uniform; per-method
+ *    behaviour comes from proto annotations (fleet/billing are `public`,
+ *    TripService requires auth).
  *
  * What env changes:
  *  - `enabledServices` — which of the three are mounted locally (undefined =
@@ -22,7 +23,7 @@ import { createServer } from "@connectum/core";
 import type { Server } from "@connectum/core";
 import type { Interceptor } from "@connectrpc/connect";
 import { Healthcheck } from "@connectum/healthcheck";
-import { createDefaultInterceptors } from "@connectum/interceptors";
+import { createDefaultInterceptors, createErrorHandlerInterceptor } from "@connectum/interceptors";
 import { Reflection } from "@connectum/reflection";
 import { serviceCatalog } from "#gen/catalog.gen.ts";
 import { buildAuthInterceptors } from "#auth.ts";
@@ -60,9 +61,14 @@ export function buildServer(options: BuildServerOptions = {}): Server {
 
     const otelInterceptor = buildOtelInterceptor();
     const interceptors: Interceptor[] = [
-        ...createDefaultInterceptors(),
-        ...(otelInterceptor ? [otelInterceptor] : []),
+        // ADR-024 chain order: errorHandler first, then auth/authz immediately
+        // after it (so unauthenticated requests are rejected before validation),
+        // then OTel — placed after authz so getAuthContext() is populated for
+        // enduser span attributes — then the default validation chain.
+        createErrorHandlerInterceptor(),
         ...buildAuthInterceptors({ secret: jwtSecret }),
+        ...(otelInterceptor ? [otelInterceptor] : []),
+        ...createDefaultInterceptors({ errorHandler: false }),
     ];
 
     return createServer({

--- a/extensions/redact/README.md
+++ b/extensions/redact/README.md
@@ -1,10 +1,10 @@
 # Redact Extension Example
 
-Demonstrates how to implement sensitive data redaction for RPC responses using custom proto extensions.
+Demonstrates how to implement sensitive data redaction for RPC requests and responses using custom proto extensions.
 
 ## Overview
 
-This extension automatically redacts fields marked with `(connectum.options.sensitive) = true` from RPC responses, preventing sensitive data from leaking into logs and traces.
+This extension automatically redacts fields marked with `(connectum.options.sensitive) = true` from both the request input and the response output of unary RPC methods, preventing sensitive data from leaking into logs and traces.
 
 ## Usage
 
@@ -24,9 +24,12 @@ await server.start();
 
 ## Proto Definition
 
-```protobuf
-import "connectum/options.proto";
+> Illustrative only. This example does not ship a generated `connectum/options.proto`; the
+> `connectum.options.sensitive` / `connectum.options.use_sensitive` options are hand-rolled
+> stubs defined in `extensions.ts` (extension field numbers 50001/50002). The block below shows
+> the proto shape these stubs emulate — replace it with a real generated option once one exists.
 
+```protobuf
 message CodeVerifyRequest {
     string code = 1 [(connectum.options.sensitive) = true];
 }
@@ -34,5 +37,6 @@ message CodeVerifyRequest {
 
 ## Dependencies
 
+- `@connectum/core` — Server foundation (`createServer`)
 - `@bufbuild/protobuf` — Proto message handling
 - `@connectrpc/connect` — ConnectRPC interceptor type

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -44,7 +44,7 @@ The service is plain TypeScript — it runs unchanged on Node.js, Bun and tsx:
 ```bash
 pnpm start          # Node.js (native type stripping)
 pnpm start:bun      # Bun
-pnpm start:tsx      # tsx (any Node.js 22+)
+pnpm start:tsx      # tsx
 ```
 
 ## Next

--- a/hris/README.md
+++ b/hris/README.md
@@ -80,6 +80,7 @@ src/
   services/timeOffService.ts         # ctx.call validation + publishes LeaveApproved
   services/payrollService.ts         # GetBalance + LeaveApproved subscriber route
   topology.ts                        # env → enabledServices + remoteResolver
+  events.ts                          # LEAVE_APPROVED_TOPIC constant (publisher/subscriber match)
   eventBus.ts                        # one bus per process; payroll subscribes only when local
   server.ts                          # buildServer() — same code, both topologies
   index.ts                           # env-driven entry point

--- a/interceptors/jwt/README.md
+++ b/interceptors/jwt/README.md
@@ -26,3 +26,4 @@ const transport = createConnectTransport({
 ## Dependencies
 
 - `@connectrpc/connect` — ConnectRPC interceptor type
+- `@connectrpc/connect-node` — Node.js transport (`createConnectTransport`) used in the Usage example

--- a/o11y-coroot/README.md
+++ b/o11y-coroot/README.md
@@ -181,6 +181,8 @@ Business metrics from `getMeter()` — order rates by product, stock availabilit
 | `clickhouse-users.xml`      | ClickHouse user permissions for Docker network           |
 | `scripts/generate-traffic.sh`| Traffic generation script with progress reporting        |
 | `service/`                   | Shared microservice source (order + inventory)           |
+| `ARCHITECTURE.md`            | Coroot architecture & Docker deployment notes            |
+| `DASHBOARD.md`               | PromQL queries for a custom business-metrics dashboard   |
 
 ## Node Agent (Linux Only)
 

--- a/performance-test-server/README.md
+++ b/performance-test-server/README.md
@@ -18,7 +18,7 @@ This allows k6 benchmarks to accurately measure the overhead introduced by each 
 
 ## Requirements
 
-- **Node.js**: >=25.2.0
+- **Node.js**: >=25.2.0 — required because this example runs its TypeScript sources directly via native type stripping (`node src/index.ts`). Consuming the framework as compiled packages needs only Node.js >=22.13.0.
 - **pnpm**: >=10
 
 ## Installation
@@ -43,6 +43,9 @@ node examples/performance-test-server/src/index.ts
 # Or with auto-reload during development
 node --watch examples/performance-test-server/src/index.ts
 ```
+
+> From within `examples/performance-test-server`, the equivalent package.json
+> scripts are available: `pnpm start` and `pnpm dev` (auto-reload).
 
 Expected output:
 
@@ -306,4 +309,4 @@ pnpm install
 
 ## License
 
-Apache 2.0
+Apache-2.0

--- a/with-custom-interceptor/src/interceptors/rateLimitInterceptor.ts
+++ b/with-custom-interceptor/src/interceptors/rateLimitInterceptor.ts
@@ -2,7 +2,7 @@
  * Rate Limit Interceptor
  *
  * Limits request rate for the RateLimitedEcho RPC method using
- * a sliding window counter per client IP address.
+ * a fixed-window counter per client IP address.
  *
  * @module rateLimitInterceptor
  */

--- a/with-events-amqp/README.md
+++ b/with-events-amqp/README.md
@@ -119,7 +119,7 @@ docker compose down
 
 ### Step 1. RabbitMQ Management UI — Overview
 
-After running `docker compose up -d`, open http://localhost:15672 and log in with guest/guest. The Overview tab shows node status, message rates, and connection counts.
+After running `docker compose up -d rabbitmq` (per the Quick Start above), open http://localhost:15672 and log in with guest/guest. The Overview tab shows node status, message rates, and connection counts.
 
 ![RabbitMQ Overview](screenshots/screenshot-overview.png)
 

--- a/with-events-dlq/README.md
+++ b/with-events-dlq/README.md
@@ -216,7 +216,7 @@ inventoryAdapter.subscribe(
 | `dlq.original-topic` | Topic the event was originally published to |
 | `dlq.original-id` | Unique event ID from the original message |
 | `dlq.error` | Error message from the last failed handler invocation |
-| `dlq.attempt` | Number of attempts made before routing to DLQ |
+| `dlq.attempt` | Delivery attempt number (1-based) of the original message at the broker. NATS does not redeliver here, so retries are in-process and this stays `1`. |
 
 ## EventBus Configuration
 
@@ -232,7 +232,13 @@ export const inventoryEventBus = createEventBus({
     group: "inventory-service",
     middleware: {
         retry: { maxRetries: 2, backoff: "fixed", initialDelay: 200 },
-        dlq: { topic: "dead-letter-queue" },
+        dlq: {
+            topic: "dead-letter-queue",
+            // Emit the full error message into dlq.error. Without a custom
+            // errorSerializer the framework default emits only the error NAME
+            // (error.name) to avoid leaking sensitive data into the DLQ.
+            errorSerializer: (err) => (err instanceof Error ? err.message : String(err)),
+        },
     },
 });
 ```

--- a/with-events-redpanda/README.md
+++ b/with-events-redpanda/README.md
@@ -322,11 +322,13 @@ services:
     ports: ["8080:8080"]
 
   order-service:               # Order microservice
+    build: .                   # built from the local Dockerfile
     ports: ["5001:5001"]
     environment:
       - REDPANDA_BROKERS=redpanda:29092
 
   inventory-service:           # Inventory microservice
+    build: .                   # built from the local Dockerfile
     ports: ["5002:5002"]
     environment:
       - REDPANDA_BROKERS=redpanda:29092


### PR DESCRIPTION
## Summary

Example READMEs aligned with the published 1.0.0 surface, plus one verified code
fix in the `car-sharing` flagship.

### car-sharing interceptor order (ADR-024)
The gateway chain placed authentication after validation/observability. It now
follows ADR-024 — `errorHandler → JWT auth → proto authz → OTel → validation` —
so unauthenticated requests are rejected before validation, and OTel runs after
authz so `getAuthContext()` is populated for `enduser.*` span attributes.
Verified: `tsc --noEmit` clean, e2e **7/7** pass.

The `car-sharing` Dockerfile now builds without a committed lockfile (`pnpm
install` resolves `@connectum/*` to the published 1.0.0 versions), matching the
example's no-committed-lockfile policy.

### README fixes
- `extensions/redact`: the illustrative proto block is marked as hand-rolled
  stubs (no `connectum/options.proto` exists).
- `getting-started`: Node floor consistency (`>=25.2.0` for run-directly TS).
- `with-events-dlq`: DLQ metadata description and the `errorSerializer` note.
- Missing dependencies in `extensions/redact` and `interceptors/jwt`; `hris`
  layout; `with-custom-interceptor` doc comment (fixed-window).

Part of a coordinated 1.0.0 documentation pass with companion PRs in the
framework and docs repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3
