### PR TITLE
feat(car-sharing): back FleetService with Drizzle + Postgres (Phase 1)

### DIFF
--- a/car-sharing/README.md
+++ b/car-sharing/README.md
@@ -20,8 +20,12 @@ wiring.
 | Service                   | Role            | RPC                          | Auth                                  |
 | ------------------------- | --------------- | ---------------------------- | ------------------------------------- |
 | `trips.v1.TripService`    | edge / gateway  | `StartTrip(userId, vehicle)` | JWT required (proto `default_policy: allow`) |
-| `fleet.v1.FleetService`   | internal leaf   | `GetVehicle(id)`             | `public` (proto `service_auth.public`) |
+| `fleet.v1.FleetService`   | internal leaf   | `GetVehicle`, `ListVehicles` (stream), `ReserveVehicle`, `ReleaseVehicle` | `public` (proto `service_auth.public`) |
 | `billing.v1.BillingService` | internal leaf | `OpenTab(tripId)`            | `public`                              |
+
+`FleetService` is backed by a real database (Drizzle ORM + Postgres) — see
+[Persistence](#persistence-fleetservice--drizzle--postgres). The trip/billing
+services remain in-memory for now (later phases).
 
 `StartTrip` orchestrates two cross-service calls:
 
@@ -108,11 +112,77 @@ pnpm test             # in-process e2e: gateway auth, ctx.call, error paths
 pnpm start            # monolith on :5000 (SERVICES unset)
 ```
 
-The e2e suite (`tests/e2e/e2e.test.ts`) runs the whole app in one process and
-asserts: the happy `StartTrip` path (both `ctx.call`s), `FAILED_PRECONDITION` for
-an unavailable vehicle, `NOT_FOUND` propagated from fleet, and the gateway
-rejecting unauthenticated / invalid-token requests while the public fleet service
-is reachable without a token.
+The e2e suite runs the whole app in one process and asserts: the happy
+`StartTrip` path (both `ctx.call`s), `FAILED_PRECONDITION` for an unavailable
+vehicle, `NOT_FOUND` propagated from fleet, the gateway rejecting unauthenticated
+/ invalid-token requests while the public fleet service is reachable without a
+token (`tests/e2e/e2e.test.ts`), and the full FleetService persistence surface —
+`GetVehicle`, streaming `ListVehicles` with filter + cursor pagination,
+`ReserveVehicle`/`ReleaseVehicle` — over a real gRPC client
+(`tests/e2e/fleet.test.ts`).
+
+## Persistence: FleetService + Drizzle + Postgres
+
+FleetService is the vehicle **system of record**, backed by [Drizzle ORM](https://orm.drizzle.team)
+over Postgres (the [`postgres`](https://github.com/porsager/postgres) / postgres.js
+driver). The `vehicles` table (`src/db/schema.ts`) carries `id`, `model`,
+`available`, a lifecycle `status` (`available` | `reserved` | `maintenance`),
+`lat`/`lng`, and `updated_at`. The invariant the service keeps is
+`available <=> status === "available"`.
+
+The RPC surface demonstrates a realistic data-access layer:
+
+- **`GetVehicle`** — point read; `NOT_FOUND` on an unknown id. Still returns
+  `Vehicle.available`, which the trip handler's `ctx.call` depends on.
+- **`ListVehicles`** — **server-streaming** complex query: a SQL
+  `where`/`order by id`/`limit` with **cursor pagination** (the client re-sends
+  the last streamed `Vehicle.id` as `page_token`), optionally filtered to
+  available vehicles via `available_only`.
+- **`ReserveVehicle`** — atomic `UPDATE … WHERE id=? AND available=true`;
+  `FAILED_PRECONDITION` if already reserved / in maintenance, `NOT_FOUND` if
+  unknown.
+- **`ReleaseVehicle`** — returns a vehicle to the available pool;
+  `FAILED_PRECONDITION` for a maintenance vehicle, `NOT_FOUND` if unknown.
+
+### Dependency injection — why the tests need no Docker
+
+`buildServer({ db })` injects the database into `createFleetService(db)`. In
+production that `db` is a postgres.js client over `DATABASE_URL`; the **e2e tests
+inject a [PGlite](https://pglite.dev) in-process Postgres** through the same
+parameter — Postgres compiled to WASM, no container required. `src/db/schema.ts`
+is the schema source of truth; `pnpm db:generate` derives versioned SQL into
+`drizzle/`. Both the docker-compose flow (`pnpm db:migrate`) and the PGlite test
+migrator apply those **same** generated migrations, then seed the shared fleet
+(`src/db/seed.ts`) — so the persistence e2e is fully real but self-contained.
+
+### Run with Postgres (docker-compose)
+
+The repo ships a `docker-compose.yml` with a Postgres service (healthcheck) and
+the app wired via `DATABASE_URL`:
+
+```bash
+docker compose up -d postgres            # start Postgres only
+
+# Apply migrations and seed the fleet (DATABASE_URL points at the compose Postgres):
+export DATABASE_URL=postgresql://car_sharing:car_sharing@localhost:5432/car_sharing
+pnpm db:migrate                          # apply drizzle/ migrations → vehicles table
+pnpm db:seed                             # seed the demo fleet
+
+docker compose up app                    # monolith on :5000 against Postgres
+```
+
+Schema/migration scripts:
+
+| Command           | Purpose                                                              |
+| ----------------- | ------------------------------------------------------------------- |
+| `pnpm db:generate`| Generate versioned SQL migrations from `src/db/schema.ts` → `drizzle/` |
+| `pnpm db:migrate` | Apply the `drizzle/` migrations to the Postgres at `DATABASE_URL` (same files the test migrator applies) |
+| `pnpm db:push`    | Dev convenience: diff-sync `schema.ts` to the DB without migrations  |
+| `pnpm db:seed`    | Seed the demo fleet (drops + inserts `src/db/seed.ts`)              |
+
+> `pnpm start` / `pnpm dev` now require `DATABASE_URL` (FleetService opens its
+> connection lazily on the first query). The e2e tests do **not** — they inject
+> PGlite.
 
 ### `ctx.call` error propagation
 
@@ -209,17 +279,23 @@ Point `OTEL_EXPORTER_OTLP_ENDPOINT` at your Collector (the manifests assume
 car-sharing/
 ├── proto/                      fleet, trips, billing protos (+ auth options import)
 ├── src/
-│   ├── services/               fleetService, billingService, tripService (ctx.call)
+│   ├── db/                     Drizzle: schema.ts, client.ts (Db DI), seed.ts
+│   ├── services/               fleetService (Drizzle), billingService, tripService
 │   ├── topology.ts             env → mono/split (SERVICES + perServiceEnvResolver)
 │   ├── auth.ts                 JWT + proto authz interceptors (uniform chain)
 │   ├── observability.ts        env-gated OpenTelemetry wiring
-│   ├── server.ts               buildServer() — services + catalog + interceptors
+│   ├── server.ts               buildServer() — services + catalog + interceptors + db
 │   └── index.ts                entry point (role by SERVICES)
-├── tests/e2e/e2e.test.ts       monolith, in-process gateway e2e
+├── drizzle/                    generated SQL migrations (single source of truth)
+├── drizzle.config.ts           drizzle-kit config (schema → migrations / push)
+├── tests/
+│   ├── helpers/db.ts           PGlite test db (migrate + seed), injected via DI
+│   └── e2e/                     e2e.test.ts (gateway/ctx.call) + fleet.test.ts (persistence)
 ├── k8s/                        namespace, rbac, secret, configmap, deployments,
 │                               services, hpa
 ├── istio/                      peer-auth, authz, destination-rule, virtual-service,
 │                               gateway, canary
+├── docker-compose.yml          local monolith + Postgres (healthcheck)
 ├── Dockerfile                  one multi-stage image, role by env
 ├── buf.yaml / buf.gen.yaml     dual-module (own protos + auth options) + catalog plugin
 ├── package.json / tsconfig.json / pnpm-workspace.yaml

--- a/car-sharing/docker-compose.yml
+++ b/car-sharing/docker-compose.yml
@@ -1,0 +1,51 @@
+# Local monolith stack — the car-sharing app + its Postgres (Phase 1 persistence).
+#
+# FleetService is backed by Drizzle ORM over Postgres. This compose file brings
+# up Postgres with a healthcheck and runs the app as the monolith (every service
+# in-process, SERVICES unset), wired to the database via DATABASE_URL.
+#
+# First run — apply migrations and seed the fleet:
+#
+#   docker compose up -d postgres            # start Postgres only
+#   DATABASE_URL=postgresql://car_sharing:car_sharing@localhost:5432/car_sharing \
+#     pnpm db:migrate                        # apply drizzle/ migrations → vehicles table
+#   DATABASE_URL=postgresql://car_sharing:car_sharing@localhost:5432/car_sharing \
+#     pnpm db:seed                           # seed the demo fleet
+#   docker compose up app                    # start the app (monolith on :5000)
+#
+# The e2e tests do NOT need this — they use an in-process PGlite Postgres.
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: car_sharing
+      POSTGRES_PASSWORD: car_sharing
+      POSTGRES_DB: car_sharing
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U car_sharing -d car_sharing"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+  app:
+    build: .
+    image: car-sharing:local
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      PORT: "5000"
+      # Monolith: SERVICES unset → every service mounted in-process.
+      DATABASE_URL: postgresql://car_sharing:car_sharing@postgres:5432/car_sharing
+    ports:
+      - "5000:5000"
+
+volumes:
+  pgdata:

--- a/car-sharing/drizzle.config.ts
+++ b/car-sharing/drizzle.config.ts
@@ -1,0 +1,23 @@
+/**
+ * drizzle-kit config — generates SQL migrations from `src/db/schema.ts` and
+ * pushes/applies them to the Postgres at `DATABASE_URL`.
+ *
+ *  - `pnpm db:generate` writes versioned SQL into `drizzle/` (committed). Those
+ *    migrations are applied by `pnpm db:migrate` (docker-compose / prod) and by
+ *    the e2e PGlite migrator — same files, one source of truth.
+ *  - `pnpm db:push` is a dev convenience that diff-syncs `schema.ts` to the DB
+ *    without going through the migration files.
+ *
+ * @module drizzle.config
+ */
+
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+    dialect: "postgresql",
+    schema: "./src/db/schema.ts",
+    out: "./drizzle",
+    dbCredentials: {
+        url: process.env.DATABASE_URL ?? "postgresql://car_sharing:car_sharing@localhost:5432/car_sharing",
+    },
+});

--- a/car-sharing/drizzle/0000_big_christian_walker.sql
+++ b/car-sharing/drizzle/0000_big_christian_walker.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "vehicles" (
+	"id" text PRIMARY KEY NOT NULL,
+	"model" text NOT NULL,
+	"available" boolean NOT NULL,
+	"status" text NOT NULL,
+	"lat" double precision,
+	"lng" double precision,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/car-sharing/drizzle/meta/0000_snapshot.json
+++ b/car-sharing/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,75 @@
+{
+  "id": "3e01871f-ef91-4cb5-87c9-08bacaa6a942",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lat": {
+          "name": "lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/car-sharing/drizzle/meta/_journal.json
+++ b/car-sharing/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1781980551863,
+      "tag": "0000_big_christian_walker",
+      "breakpoints": true
+    }
+  ]
+}

--- a/car-sharing/package.json
+++ b/car-sharing/package.json
@@ -15,6 +15,10 @@
     "buf:generate": "buf generate",
     "buf:lint": "buf lint",
     "build:proto": "pnpm run buf:generate",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push",
+    "db:seed": "node src/db/seed.ts",
     "test": "node --test tests/**/*.test.ts",
     "docker:build": "docker build -t car-sharing:local ."
   },
@@ -47,13 +51,17 @@
     "@connectum/healthcheck": "^1.0.0",
     "@connectum/interceptors": "^1.0.0",
     "@connectum/otel": "^1.0.0",
-    "@connectum/reflection": "^1.0.0"
+    "@connectum/reflection": "^1.0.0",
+    "drizzle-orm": "^0.45.0",
+    "postgres": "^3.4.0"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",
     "@bufbuild/protoc-gen-es": "^2.11.0",
     "@connectum/protoc-gen-catalog": "^1.0.0",
+    "@electric-sql/pglite": "^0.5.0",
     "@types/node": "^25.2.0",
+    "drizzle-kit": "^0.31.0",
     "typescript": "^5.9.3"
   }
 }

--- a/car-sharing/proto/fleet/v1/fleet.proto
+++ b/car-sharing/proto/fleet/v1/fleet.proto
@@ -15,11 +15,35 @@ import "connectum/auth/v1/options.proto";
 // rejected as unauthenticated by the same interceptor chain that protects the
 // edge. In production the network boundary is enforced by Istio mTLS + an
 // AuthorizationPolicy that only admits the trips ServiceAccount (see istio/).
+//
+// Persistence (Phase 1): the fleet is the only service backed by a real
+// database — Drizzle ORM over Postgres (postgres.js). Tests inject a PGlite
+// in-process Postgres via the same DI the server uses, so no Docker is needed.
 service FleetService {
   option (connectum.auth.v1.service_auth) = { public: true };
 
   // GetVehicle returns a vehicle by id, or NOT_FOUND if unknown.
   rpc GetVehicle(GetVehicleRequest) returns (GetVehicleResponse) {}
+
+  // ListVehicles streams vehicles matching a filter, page by page.
+  //
+  // Server-streaming: the handler is a SQL query (`where`/`order by id`/`limit`)
+  // with cursor pagination — the caller re-sends the id of the last streamed
+  // vehicle as `page_token` to fetch the next page. With `available_only` the
+  // query is narrowed to currently available vehicles.
+  rpc ListVehicles(ListVehiclesRequest) returns (stream Vehicle) {}
+
+  // ReserveVehicle marks a vehicle reserved (available=false,
+  // status="reserved") and returns it. NOT_FOUND if the id is unknown;
+  // FAILED_PRECONDITION if the vehicle is already reserved or in maintenance
+  // (not currently available).
+  rpc ReserveVehicle(ReserveVehicleRequest) returns (Vehicle) {}
+
+  // ReleaseVehicle returns a vehicle to the available pool (available=true,
+  // status="available") and returns it. NOT_FOUND if the id is unknown.
+  // FAILED_PRECONDITION if the vehicle is in maintenance (cannot be released
+  // back into service from the fleet API).
+  rpc ReleaseVehicle(ReleaseVehicleRequest) returns (Vehicle) {}
 }
 
 message GetVehicleRequest {
@@ -30,8 +54,42 @@ message GetVehicleResponse {
   Vehicle vehicle = 1;
 }
 
+message ListVehiclesRequest {
+  // When true, only vehicles that are currently available are streamed.
+  bool available_only = 1;
+  // Max vehicles per page. Server clamps to a sane default/max when 0 or large.
+  int32 page_size = 2;
+  // Cursor: the id of the last vehicle from the previous page. Empty = first
+  // page. The stream itself carries no token, so the client derives the cursor
+  // from the last streamed Vehicle.id.
+  string page_token = 3;
+}
+
+message ReserveVehicleRequest {
+  string id = 1;
+}
+
+message ReleaseVehicleRequest {
+  string id = 1;
+}
+
+// Location is a vehicle's last-known position.
+message Location {
+  double lat = 1;
+  double lng = 2;
+}
+
 message Vehicle {
   string id = 1;
   string model = 2;
+  // available <=> status == "available". Kept for the trip handler, which only
+  // checks availability.
   bool available = 3;
+  // Lifecycle state: "available" | "reserved" | "maintenance". Modeled as a
+  // string (not a proto enum) so the generated TypeScript stays erasable —
+  // this example's tsconfig sets `erasableSyntaxOnly`, which rejects the native
+  // `enum` that protoc-gen-es emits. The string domain is pinned in code via a
+  // `const` object (see src/db/schema.ts VehicleStatus).
+  string status = 4;
+  Location location = 5;
 }

--- a/car-sharing/src/db/client.ts
+++ b/car-sharing/src/db/client.ts
@@ -1,0 +1,43 @@
+/**
+ * Drizzle client factory — the app's Postgres connection.
+ *
+ * Production/dev connect over postgres.js to `DATABASE_URL` (the docker-compose
+ * Postgres). The service does NOT import this directly: `buildServer` injects a
+ * `Db` into `createFleetService`, so tests can pass a PGlite-backed Drizzle db
+ * (an in-process Postgres) instead — no Docker needed for the e2e.
+ *
+ * The exported {@link Db} type is the common supertype of BOTH drivers'
+ * databases (postgres.js and PGlite both extend `PgDatabase`), so either can be
+ * injected wherever a `Db` is expected.
+ *
+ * @module db/client
+ */
+
+import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
+import { drizzle } from "drizzle-orm/postgres-js";
+import * as schema from "#db/schema.ts";
+
+/**
+ * Driver-agnostic Drizzle database type bound to the app schema.
+ *
+ * Both `drizzle-orm/postgres-js` and `drizzle-orm/pglite` return subclasses of
+ * `PgDatabase`, so typing against the base lets the test inject a PGlite db and
+ * the server inject a postgres.js db through the same `Db` parameter.
+ */
+export type Db = PgDatabase<PgQueryResultHKT, typeof schema>;
+
+/**
+ * Create a Drizzle client over postgres.js from a connection URL.
+ *
+ * postgres.js connects lazily (no socket is opened until the first query), so
+ * constructing this in monolith/test mode where the fleet db is overridden is
+ * harmless — the default connection is never used.
+ *
+ * @param url - Postgres connection string; defaults to `DATABASE_URL`.
+ */
+export function createDb(url: string | undefined = process.env.DATABASE_URL): Db {
+    if (url === undefined || url === "") {
+        throw new Error("DATABASE_URL is not set — cannot create the fleet database client. " + "Set DATABASE_URL (see docker-compose.yml) or inject a Db (tests use PGlite).");
+    }
+    return drizzle(url, { schema });
+}

--- a/car-sharing/src/db/schema.ts
+++ b/car-sharing/src/db/schema.ts
@@ -1,0 +1,55 @@
+/**
+ * Drizzle schema — the fleet's `vehicles` table (Phase 1 persistence).
+ *
+ * FleetService is the only service backed by a real database. The table is the
+ * vehicle system of record: a row per vehicle with its model, availability,
+ * lifecycle `status`, last-known location, and an `updatedAt` audit column.
+ *
+ * `status` is a free-text column whose domain is pinned in code by
+ * {@link VehicleStatus} (proto models it as a plain string; see fleet.proto for
+ * why a native proto enum is avoided under `erasableSyntaxOnly`). The invariant
+ * the service maintains is `available <=> status === "available"`.
+ *
+ * @module db/schema
+ */
+
+import { boolean, doublePrecision, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Vehicle lifecycle states. A `const` object (ADR-001: no `enum`) — the string
+ * domain stored in {@link vehicles}.`status`.
+ */
+export const VehicleStatus = {
+    AVAILABLE: "available",
+    RESERVED: "reserved",
+    MAINTENANCE: "maintenance",
+} as const;
+
+/** One of the {@link VehicleStatus} string values. */
+export type VehicleStatus = (typeof VehicleStatus)[keyof typeof VehicleStatus];
+
+/**
+ * `vehicles` — the fleet system of record.
+ *
+ *  - `id`        text primary key (e.g. `v-001`).
+ *  - `model`     human-readable model name.
+ *  - `available` derived boolean, kept in sync with `status`.
+ *  - `status`    {@link VehicleStatus} string.
+ *  - `lat`/`lng` last-known position (nullable; double precision so it maps to
+ *                the proto `double` location fields without string coercion).
+ *  - `updatedAt` last mutation timestamp (defaults to now()).
+ */
+export const vehicles = pgTable("vehicles", {
+    id: text("id").primaryKey(),
+    model: text("model").notNull(),
+    available: boolean("available").notNull(),
+    status: text("status").notNull(),
+    lat: doublePrecision("lat"),
+    lng: doublePrecision("lng"),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+/** A selected `vehicles` row. */
+export type VehicleRow = typeof vehicles.$inferSelect;
+/** An insertable `vehicles` row. */
+export type NewVehicleRow = typeof vehicles.$inferInsert;

--- a/car-sharing/src/db/seed.ts
+++ b/car-sharing/src/db/seed.ts
@@ -1,0 +1,54 @@
+/**
+ * Seed data + seeding routine for the fleet `vehicles` table.
+ *
+ * The first three rows reproduce the original in-memory fleet so the existing
+ * trip/billing flows keep working unchanged:
+ *   - v-001 Tesla Model 3   — available
+ *   - v-002 Renault Zoe     — available
+ *   - v-003 VW ID.3         — maintenance (unavailable)
+ * A few more available/reserved vehicles follow so `ListVehicles` pagination and
+ * the `available_only` filter are demonstrable.
+ *
+ * `seedVehicles(db)` is idempotent-ish for demos: it deletes existing rows then
+ * inserts the seed set, so re-running (`pnpm db:seed`) or re-seeding between
+ * tests yields a known state. Reused by both the CLI script (bottom of file) and
+ * the e2e test helper.
+ *
+ * @module db/seed
+ */
+
+import { VehicleStatus, vehicles } from "#db/schema.ts";
+import type { Db } from "#db/client.ts";
+import type { NewVehicleRow } from "#db/schema.ts";
+
+/** The demo fleet. `available` is kept in sync with `status` per the invariant. */
+export const SEED_VEHICLES: ReadonlyArray<NewVehicleRow> = [
+    { id: "v-001", model: "Tesla Model 3", status: VehicleStatus.AVAILABLE, available: true, lat: 52.5200, lng: 13.4050 },
+    { id: "v-002", model: "Renault Zoe", status: VehicleStatus.AVAILABLE, available: true, lat: 52.5170, lng: 13.3889 },
+    { id: "v-003", model: "VW ID.3", status: VehicleStatus.MAINTENANCE, available: false, lat: 52.4900, lng: 13.4200 },
+    { id: "v-004", model: "BMW i3", status: VehicleStatus.AVAILABLE, available: true, lat: 52.5300, lng: 13.3850 },
+    { id: "v-005", model: "Hyundai Ioniq 5", status: VehicleStatus.AVAILABLE, available: true, lat: 52.5450, lng: 13.3550 },
+    { id: "v-006", model: "Nissan Leaf", status: VehicleStatus.RESERVED, available: false, lat: 52.5060, lng: 13.4300 },
+    { id: "v-007", model: "Polestar 2", status: VehicleStatus.AVAILABLE, available: true, lat: 52.5100, lng: 13.4500 },
+];
+
+/**
+ * Replace the fleet with the {@link SEED_VEHICLES} set.
+ *
+ * @param db - Drizzle db (postgres.js in prod, PGlite in tests).
+ */
+export async function seedVehicles(db: Db): Promise<void> {
+    await db.delete(vehicles);
+    await db.insert(vehicles).values([...SEED_VEHICLES]);
+}
+
+// CLI entrypoint: `pnpm db:seed`. Connects over postgres.js to DATABASE_URL,
+// seeds, and exits. Guarded so importing this module (e.g. from the test helper)
+// does NOT open a database connection.
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const { createDb } = await import("#db/client.ts");
+    const db = createDb();
+    await seedVehicles(db);
+    console.log(`Seeded ${SEED_VEHICLES.length} vehicles.`);
+    process.exit(0);
+}

--- a/car-sharing/src/server.ts
+++ b/car-sharing/src/server.ts
@@ -27,9 +27,11 @@ import { createDefaultInterceptors, createErrorHandlerInterceptor } from "@conne
 import { Reflection } from "@connectum/reflection";
 import { serviceCatalog } from "#gen/catalog.gen.ts";
 import { buildAuthInterceptors } from "#auth.ts";
+import { createDb } from "#db/client.ts";
+import type { Db } from "#db/client.ts";
 import { buildOtelInterceptor } from "#observability.ts";
 import { billingService } from "#services/billingService.ts";
-import { fleetService } from "#services/fleetService.ts";
+import { createFleetService } from "#services/fleetService.ts";
 import { tripService } from "#services/tripService.ts";
 import { resolveTopology } from "#topology.ts";
 import type { Topology } from "#topology.ts";
@@ -45,6 +47,14 @@ export interface BuildServerOptions {
     readonly topology?: Topology;
     /** JWT secret override (tests inject the shared test secret). Defaults to `JWT_SECRET` env. */
     readonly jwtSecret?: string;
+    /**
+     * Fleet database override. Tests inject a PGlite-backed Drizzle db so the
+     * e2e runs without Docker; defaults to a postgres.js client over
+     * `DATABASE_URL` (see `#db/client.ts`). Injected for EVERY topology that
+     * mounts the fleet (including the monolith, where the trip handler's
+     * `ctx.call` to FleetService runs in-process).
+     */
+    readonly db?: Db;
 }
 
 /**
@@ -58,6 +68,12 @@ export function buildServer(options: BuildServerOptions = {}): Server {
     const topology = options.topology ?? resolveTopology();
     const port = options.port ?? Number(process.env.PORT ?? 5000);
     const jwtSecret = options.jwtSecret ?? process.env.JWT_SECRET ?? DEV_JWT_SECRET;
+
+    // Fleet persistence. postgres.js connects lazily, so constructing the
+    // default db is harmless even when the fleet isn't mounted locally; the
+    // connection is opened only when FleetService actually queries.
+    const db = options.db ?? createDb();
+    const fleetService = createFleetService(db);
 
     const otelInterceptor = buildOtelInterceptor();
     const interceptors: Interceptor[] = [

--- a/car-sharing/src/services/fleetService.ts
+++ b/car-sharing/src/services/fleetService.ts
@@ -1,13 +1,28 @@
 /**
- * FleetService — the vehicle system of record (a leaf service).
+ * FleetService — the vehicle system of record, now backed by Drizzle + Postgres.
  *
- * Defined with `defineService`: handlers receive a Connectum `ctx`, but this
- * service makes no cross-service calls of its own. It owns an in-memory vehicle
- * map and returns `Code.NotFound` for an unknown id.
+ * This is the only persistent service (Phase 1). It is built by a factory,
+ * `createFleetService(db)`, so the database is injected: `buildServer` passes a
+ * postgres.js-backed Drizzle db in production, while the e2e injects a PGlite
+ * (in-process Postgres) db through the same parameter — no Docker for tests.
  *
- * Internal-only: reached by the trip handler via `ctx.call`, never by external
- * clients. Its proto marks every method `public` so the gateway auth/authz
- * interceptors skip it (an internal `ctx.call` carries no Authorization header).
+ * Handlers map SQL rows to the `Vehicle` proto message. The invariant kept
+ * across mutations is `available <=> status === "available"`.
+ *
+ *  - GetVehicle     — point read; NOT_FOUND on unknown id. Still returns
+ *                     `Vehicle.available`, which the trip handler depends on.
+ *  - ListVehicles   — server-streaming: a `where`/`order by id`/`limit` query
+ *                     with cursor pagination (the caller re-sends the last
+ *                     streamed id as `page_token`), optionally filtered to
+ *                     available vehicles.
+ *  - ReserveVehicle — atomic `UPDATE ... WHERE id=? AND available=true`;
+ *                     NOT_FOUND on unknown id, FAILED_PRECONDITION when already
+ *                     reserved / in maintenance.
+ *  - ReleaseVehicle — returns a vehicle to the available pool; NOT_FOUND on
+ *                     unknown id, FAILED_PRECONDITION when in maintenance.
+ *
+ * Internal-only and `public` in proto: reached by the trip handler via
+ * `ctx.call`, never by external clients (see fleet.proto).
  *
  * @module services/fleetService
  */
@@ -15,26 +30,111 @@
 import { create } from "@bufbuild/protobuf";
 import { Code, ConnectError } from "@connectrpc/connect";
 import { defineService } from "@connectum/core";
-import { FleetService, GetVehicleResponseSchema, VehicleSchema } from "#gen/fleet/v1/fleet_pb.ts";
+import type { ServiceDefinition } from "@connectum/core";
+import { and, asc, eq, gt } from "drizzle-orm";
+import { FleetService, GetVehicleResponseSchema, LocationSchema, VehicleSchema } from "#gen/fleet/v1/fleet_pb.ts";
+import type { Vehicle } from "#gen/fleet/v1/fleet_pb.ts";
+import { VehicleStatus, vehicles } from "#db/schema.ts";
+import type { Db } from "#db/client.ts";
+import type { VehicleRow } from "#db/schema.ts";
 
-/** Seed vehicles (id → [model, available]). */
-const VEHICLES: ReadonlyArray<readonly [string, readonly [string, boolean]]> = [
-    ["v-001", ["Tesla Model 3", true]],
-    ["v-002", ["Renault Zoe", true]],
-    ["v-003", ["VW ID.3", false]], // in maintenance — unavailable
-];
+/** Default page size for ListVehicles when the request asks for 0 / negative. */
+const DEFAULT_PAGE_SIZE = 20;
+/** Hard cap on page size so a client cannot stream an unbounded page. */
+const MAX_PAGE_SIZE = 100;
 
-/** Demo vehicle fleet (id → Vehicle fields). */
-const vehicles = new Map<string, { model: string; available: boolean }>(VEHICLES.map(([id, [model, available]]) => [id, { model, available }]));
+/** Map a `vehicles` row to the wire `Vehicle` message. */
+function toVehicle(row: VehicleRow): Vehicle {
+    const location = row.lat !== null && row.lng !== null ? create(LocationSchema, { lat: row.lat, lng: row.lng }) : undefined;
+    return create(VehicleSchema, {
+        id: row.id,
+        model: row.model,
+        available: row.available,
+        status: row.status,
+        location,
+    });
+}
 
-export const fleetService = defineService(FleetService, {
-    getVehicle: (req) => {
-        const vehicle = vehicles.get(req.id);
-        if (vehicle === undefined) {
-            throw new ConnectError(`No vehicle with id "${req.id}".`, Code.NotFound);
-        }
-        return create(GetVehicleResponseSchema, {
-            vehicle: create(VehicleSchema, { id: req.id, model: vehicle.model, available: vehicle.available }),
-        });
-    },
-});
+/** Clamp a requested page size into `[1, MAX_PAGE_SIZE]`. */
+function clampPageSize(pageSize: number): number {
+    if (pageSize <= 0) return DEFAULT_PAGE_SIZE;
+    return Math.min(pageSize, MAX_PAGE_SIZE);
+}
+
+/**
+ * Build the FleetService definition over an injected Drizzle db.
+ *
+ * @param db - Drizzle database (postgres.js in prod, PGlite in tests).
+ */
+export function createFleetService(db: Db): ServiceDefinition {
+    return defineService(FleetService, {
+        async getVehicle(req) {
+            const rows = await db.select().from(vehicles).where(eq(vehicles.id, req.id)).limit(1);
+            const row = rows[0];
+            if (row === undefined) {
+                throw new ConnectError(`No vehicle with id "${req.id}".`, Code.NotFound);
+            }
+            return create(GetVehicleResponseSchema, { vehicle: toVehicle(row) });
+        },
+
+        async *listVehicles(req) {
+            const limit = clampPageSize(req.pageSize);
+
+            // Cursor pagination over a stable `order by id`: the client re-sends
+            // the last streamed id as page_token to fetch the next page. The
+            // available_only filter narrows to currently-available vehicles.
+            const cursor = req.pageToken !== "" ? gt(vehicles.id, req.pageToken) : undefined;
+            const availableFilter = req.availableOnly ? eq(vehicles.available, true) : undefined;
+            const where = and(cursor, availableFilter);
+
+            const rows = await db.select().from(vehicles).where(where).orderBy(asc(vehicles.id)).limit(limit);
+
+            for (const row of rows) {
+                yield toVehicle(row);
+            }
+        },
+
+        async reserveVehicle(req) {
+            // Atomic reserve: only flips a vehicle that is currently available.
+            // An empty result means either the id is unknown OR it was not
+            // available — a follow-up read disambiguates the error code.
+            const updated = await db
+                .update(vehicles)
+                .set({ available: false, status: VehicleStatus.RESERVED, updatedAt: new Date() })
+                .where(and(eq(vehicles.id, req.id), eq(vehicles.available, true)))
+                .returning();
+
+            const row = updated[0];
+            if (row !== undefined) {
+                return toVehicle(row);
+            }
+
+            const existing = await db.select().from(vehicles).where(eq(vehicles.id, req.id)).limit(1);
+            if (existing[0] === undefined) {
+                throw new ConnectError(`No vehicle with id "${req.id}".`, Code.NotFound);
+            }
+            throw new ConnectError(`Vehicle "${req.id}" is not available (status "${existing[0].status}").`, Code.FailedPrecondition);
+        },
+
+        async releaseVehicle(req) {
+            const existing = await db.select().from(vehicles).where(eq(vehicles.id, req.id)).limit(1);
+            const current = existing[0];
+            if (current === undefined) {
+                throw new ConnectError(`No vehicle with id "${req.id}".`, Code.NotFound);
+            }
+            // A vehicle in maintenance cannot be released back into service via
+            // the fleet API — that is an operational decision, not a release.
+            if (current.status === VehicleStatus.MAINTENANCE) {
+                throw new ConnectError(`Vehicle "${req.id}" is in maintenance and cannot be released.`, Code.FailedPrecondition);
+            }
+
+            const updated = await db
+                .update(vehicles)
+                .set({ available: true, status: VehicleStatus.AVAILABLE, updatedAt: new Date() })
+                .where(eq(vehicles.id, req.id))
+                .returning();
+
+            return toVehicle(updated[0] as VehicleRow);
+        },
+    });
+}

--- a/car-sharing/tests/e2e/e2e.test.ts
+++ b/car-sharing/tests/e2e/e2e.test.ts
@@ -38,6 +38,7 @@ import { JWT_ISSUER } from "#auth.ts";
 import { buildServer } from "#server.ts";
 import { resetTabs, tabCount } from "#services/billingService.ts";
 import { resolveTopology } from "#topology.ts";
+import { makeTestDb } from "../helpers/db.ts";
 
 describe("E2E: car-sharing monolith (in-process gateway, no cluster)", () => {
     let server: Server;
@@ -47,9 +48,12 @@ describe("E2E: car-sharing monolith (in-process gateway, no cluster)", () => {
     before(async () => {
         // Force monolith topology so fleet, trips and billing are all mounted
         // locally and ctx.call routes in-process. Inject the shared test secret
-        // so the JWT interceptor verifies tokens minted below.
+        // so the JWT interceptor verifies tokens minted below, and a
+        // PGlite-backed Drizzle db so FleetService persists without Docker (the
+        // trip handler's in-process ctx.call to GetVehicle reads from it).
         const topology = resolveTopology("*");
-        server = buildServer({ port: 0, topology, jwtSecret: TEST_JWT_SECRET });
+        const db = await makeTestDb();
+        server = buildServer({ port: 0, topology, jwtSecret: TEST_JWT_SECRET, db });
         await server.start();
         const port = server.address?.port ?? 0;
 

--- a/car-sharing/tests/e2e/fleet.test.ts
+++ b/car-sharing/tests/e2e/fleet.test.ts
@@ -1,0 +1,208 @@
+/**
+ * E2E tests — FleetService over Drizzle + PGlite (Phase 1 persistence).
+ *
+ * The fleet is the only persistent service: a PGlite in-process Postgres is
+ * migrated + seeded in the test and injected into `buildServer({ db })`, the
+ * same parameter production uses for its postgres.js client. Every assertion
+ * goes through a REAL gRPC client over HTTP/2 (the server runs
+ * `allowHTTP1: false`), exercising the actual wire path — not the db directly.
+ *
+ * FleetService is `public` (see fleet.proto), so these calls carry no token,
+ * mirroring how the trip handler reaches it via internal `ctx.call`.
+ *
+ * Covered:
+ *  - GetVehicle: point read returns the persisted Vehicle (incl. status +
+ *    location); unknown id → NOT_FOUND.
+ *  - ListVehicles (server-streaming): the unfiltered stream returns all seeds in
+ *    id order; cursor pagination (page_size + page_token) walks pages; the
+ *    available_only filter excludes reserved / maintenance vehicles.
+ *  - ReserveVehicle: flips an available vehicle to reserved; reserving an
+ *    already-reserved or maintenance vehicle → FAILED_PRECONDITION; unknown id
+ *    → NOT_FOUND.
+ *  - ReleaseVehicle: returns a reserved vehicle to the pool; maintenance →
+ *    FAILED_PRECONDITION; unknown id → NOT_FOUND.
+ *
+ * Reserve/Release mutate shared rows, so the db is re-seeded before each test.
+ */
+
+import assert from "node:assert/strict";
+import { after, before, beforeEach, describe, it } from "node:test";
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import type { Client } from "@connectrpc/connect";
+import type { Server } from "@connectum/core";
+import { FleetService, GetVehicleRequestSchema, ListVehiclesRequestSchema, ReleaseVehicleRequestSchema, ReserveVehicleRequestSchema } from "#gen/fleet/v1/fleet_pb.ts";
+import type { Vehicle } from "#gen/fleet/v1/fleet_pb.ts";
+import { buildServer } from "#server.ts";
+import type { Db } from "#db/client.ts";
+import { resolveTopology } from "#topology.ts";
+import { makeTestDb, reseed } from "../helpers/db.ts";
+
+/** Drain a server-streaming response into an array. */
+async function collect(stream: AsyncIterable<Vehicle>): Promise<Vehicle[]> {
+    const out: Vehicle[] = [];
+    for await (const v of stream) out.push(v);
+    return out;
+}
+
+describe("E2E: FleetService persistence (Drizzle + PGlite, real gRPC client)", () => {
+    let server: Server;
+    let db: Db;
+    let fleet: Client<typeof FleetService>;
+
+    before(async () => {
+        const topology = resolveTopology("*");
+        db = await makeTestDb();
+        server = buildServer({ port: 0, topology, db });
+        await server.start();
+        const port = server.address?.port ?? 0;
+        // Public service → no Authorization header needed.
+        fleet = createClient(FleetService, createGrpcTransport({ baseUrl: `http://localhost:${port}` }));
+    });
+
+    beforeEach(async () => {
+        // Reserve/Release mutate shared rows; restore the seed before each test
+        // so ordering does not couple tests.
+        await reseed(db);
+    });
+
+    after(async () => {
+        if (server.state === "running") await server.stop();
+    });
+
+    it("GetVehicle returns the persisted vehicle with status and location", async () => {
+        const res = await fleet.getVehicle(create(GetVehicleRequestSchema, { id: "v-001" }));
+        assert.equal(res.vehicle?.id, "v-001");
+        assert.equal(res.vehicle?.model, "Tesla Model 3");
+        assert.equal(res.vehicle?.available, true);
+        assert.equal(res.vehicle?.status, "available");
+        assert.equal(res.vehicle?.location?.lat, 52.52);
+        assert.equal(res.vehicle?.location?.lng, 13.405);
+    });
+
+    it("GetVehicle on an unknown id is NOT_FOUND", async () => {
+        await assert.rejects(
+            fleet.getVehicle(create(GetVehicleRequestSchema, { id: "ghost" })),
+            (err: unknown) => err instanceof ConnectError && err.code === Code.NotFound,
+        );
+    });
+
+    it("ListVehicles streams every seeded vehicle in id order (no filter)", async () => {
+        const all = await collect(fleet.listVehicles(create(ListVehiclesRequestSchema, {})));
+        assert.equal(all.length, 7);
+        assert.deepEqual(
+            all.map((v) => v.id),
+            ["v-001", "v-002", "v-003", "v-004", "v-005", "v-006", "v-007"],
+        );
+    });
+
+    it("ListVehicles paginates with page_size + page_token (cursor over the stream)", async () => {
+        // Page 1 — first three by id.
+        const page1 = await collect(fleet.listVehicles(create(ListVehiclesRequestSchema, { pageSize: 3 })));
+        assert.deepEqual(
+            page1.map((v) => v.id),
+            ["v-001", "v-002", "v-003"],
+        );
+
+        // Page 2 — cursor = last streamed id of page 1.
+        const cursor = page1[page1.length - 1]?.id ?? "";
+        const page2 = await collect(fleet.listVehicles(create(ListVehiclesRequestSchema, { pageSize: 3, pageToken: cursor })));
+        assert.deepEqual(
+            page2.map((v) => v.id),
+            ["v-004", "v-005", "v-006"],
+        );
+
+        // Page 3 — the remainder (fewer than page_size).
+        const cursor2 = page2[page2.length - 1]?.id ?? "";
+        const page3 = await collect(fleet.listVehicles(create(ListVehiclesRequestSchema, { pageSize: 3, pageToken: cursor2 })));
+        assert.deepEqual(
+            page3.map((v) => v.id),
+            ["v-007"],
+        );
+    });
+
+    it("ListVehicles with available_only excludes reserved and maintenance vehicles", async () => {
+        const available = await collect(fleet.listVehicles(create(ListVehiclesRequestSchema, { availableOnly: true })));
+        // Seeds: v-003 is maintenance, v-006 is reserved → both excluded.
+        assert.deepEqual(
+            available.map((v) => v.id),
+            ["v-001", "v-002", "v-004", "v-005", "v-007"],
+        );
+        assert.ok(available.every((v) => v.available === true));
+    });
+
+    it("ListVehicles combines available_only with cursor pagination", async () => {
+        // available seeds in id order: v-001, v-002, v-004, v-005, v-007.
+        const page1 = await collect(fleet.listVehicles(create(ListVehiclesRequestSchema, { availableOnly: true, pageSize: 2 })));
+        assert.deepEqual(
+            page1.map((v) => v.id),
+            ["v-001", "v-002"],
+        );
+
+        const cursor = page1[page1.length - 1]?.id ?? "";
+        const page2 = await collect(fleet.listVehicles(create(ListVehiclesRequestSchema, { availableOnly: true, pageSize: 2, pageToken: cursor })));
+        // The cursor skips past v-003 (maintenance) — the filter + cursor compose.
+        assert.deepEqual(
+            page2.map((v) => v.id),
+            ["v-004", "v-005"],
+        );
+        assert.ok(page2.every((v) => v.available === true));
+    });
+
+    it("ReserveVehicle flips an available vehicle to reserved", async () => {
+        const reserved = await fleet.reserveVehicle(create(ReserveVehicleRequestSchema, { id: "v-001" }));
+        assert.equal(reserved.id, "v-001");
+        assert.equal(reserved.available, false);
+        assert.equal(reserved.status, "reserved");
+
+        // The mutation is persisted — a subsequent read reflects it.
+        const after = await fleet.getVehicle(create(GetVehicleRequestSchema, { id: "v-001" }));
+        assert.equal(after.vehicle?.available, false);
+        assert.equal(after.vehicle?.status, "reserved");
+    });
+
+    it("ReserveVehicle on an already-reserved vehicle is FAILED_PRECONDITION", async () => {
+        await fleet.reserveVehicle(create(ReserveVehicleRequestSchema, { id: "v-001" }));
+        await assert.rejects(
+            fleet.reserveVehicle(create(ReserveVehicleRequestSchema, { id: "v-001" })),
+            (err: unknown) => err instanceof ConnectError && err.code === Code.FailedPrecondition,
+        );
+    });
+
+    it("ReserveVehicle on a maintenance vehicle is FAILED_PRECONDITION", async () => {
+        await assert.rejects(
+            fleet.reserveVehicle(create(ReserveVehicleRequestSchema, { id: "v-003" })),
+            (err: unknown) => err instanceof ConnectError && err.code === Code.FailedPrecondition,
+        );
+    });
+
+    it("ReserveVehicle on an unknown id is NOT_FOUND", async () => {
+        await assert.rejects(
+            fleet.reserveVehicle(create(ReserveVehicleRequestSchema, { id: "ghost" })),
+            (err: unknown) => err instanceof ConnectError && err.code === Code.NotFound,
+        );
+    });
+
+    it("ReleaseVehicle returns a reserved vehicle to the available pool", async () => {
+        await fleet.reserveVehicle(create(ReserveVehicleRequestSchema, { id: "v-001" }));
+        const released = await fleet.releaseVehicle(create(ReleaseVehicleRequestSchema, { id: "v-001" }));
+        assert.equal(released.id, "v-001");
+        assert.equal(released.available, true);
+        assert.equal(released.status, "available");
+    });
+
+    it("ReleaseVehicle on a maintenance vehicle is FAILED_PRECONDITION", async () => {
+        await assert.rejects(
+            fleet.releaseVehicle(create(ReleaseVehicleRequestSchema, { id: "v-003" })),
+            (err: unknown) => err instanceof ConnectError && err.code === Code.FailedPrecondition,
+        );
+    });
+
+    it("ReleaseVehicle on an unknown id is NOT_FOUND", async () => {
+        await assert.rejects(
+            fleet.releaseVehicle(create(ReleaseVehicleRequestSchema, { id: "ghost" })),
+            (err: unknown) => err instanceof ConnectError && err.code === Code.NotFound,
+        );
+    });
+});

--- a/car-sharing/tests/helpers/db.ts
+++ b/car-sharing/tests/helpers/db.ts
@@ -1,0 +1,45 @@
+/**
+ * Test database helper — an in-process Postgres for the e2e, no Docker.
+ *
+ * Builds a fresh PGlite-backed Drizzle db, applies the SAME drizzle-kit
+ * migrations the app uses against real Postgres (single source of truth — no
+ * hand-written DDL that could drift from `src/db/schema.ts`), and seeds it with
+ * the shared {@link seedVehicles} data so the fleet matches what the existing
+ * trip/billing e2e and the new fleet e2e expect.
+ *
+ * The returned `Db` is injected into `buildServer({ db })`, the same parameter
+ * production uses for its postgres.js client.
+ *
+ * @module tests/helpers/db
+ */
+
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+import type { Db } from "#db/client.ts";
+import * as schema from "#db/schema.ts";
+import { seedVehicles } from "#db/seed.ts";
+
+/** Absolute path to the committed drizzle-kit migrations folder. */
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+
+/**
+ * Create a migrated, seeded PGlite-backed Drizzle db for tests.
+ *
+ * Each call spins up an isolated in-memory Postgres, so test files do not share
+ * state. Re-seed within a file (e.g. in `beforeEach`) via {@link reseed} when a
+ * test mutates rows.
+ */
+export async function makeTestDb(): Promise<Db> {
+    const client = new PGlite();
+    const db = drizzle(client, { schema });
+    await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+    await seedVehicles(db);
+    return db;
+}
+
+/** Reset the fleet to the seed state (used between tests that mutate rows). */
+export async function reseed(db: Db): Promise<void> {
+    await seedVehicles(db);
+}


### PR DESCRIPTION
## What

Phase 1 of the car-sharing example evolution: replace FleetService's in-memory `Map` with a real **Drizzle ORM + Postgres** persistence layer, and give it a realistic data-access surface (a server-streaming complex query + atomic mutations). The framework still stays thin — persistence is a best-of-breed external product wired in through dependency injection.

## Changes

- **Schema** (`src/db/schema.ts`) — `vehicles` table as the single source of truth. Lifecycle `status` is a string pinned by a `const VehicleStatus` object (ADR-001: no `enum`), so the generated proto stays erasable under `erasableSyntaxOnly`. Invariant: `available <=> status === "available"`.
- **FleetService surface** (`src/services/fleetService.ts`):
  - `GetVehicle` — point read; `NOT_FOUND` on unknown id (still returns `Vehicle.available`, which the trip handler's `ctx.call` depends on).
  - `ListVehicles` — **server-streaming complex query**: `where` / `order by id` / `limit` with **cursor pagination** (`page_token` = last streamed id) and an `available_only` filter.
  - `ReserveVehicle` / `ReleaseVehicle` — atomic `UPDATE … RETURNING` that keep the availability invariant; `FAILED_PRECONDITION` / `NOT_FOUND` as appropriate.
- **Dependency injection** — `buildServer({ db })` injects the database into `createFleetService(db)`. Production uses a postgres.js client over `DATABASE_URL`; the e2e injects **PGlite** (in-process Postgres) through the same parameter, so tests need no Docker.
- **Tooling** — `docker-compose.yml` (Postgres + healthcheck), `drizzle.config.ts`, generated `drizzle/` migrations, and `db:generate` / `db:migrate` / `db:push` / `db:seed` scripts.

## Migration integrity

The e2e test migrator (`tests/helpers/db.ts`) applies the **same committed `drizzle/` migrations** that `pnpm db:migrate` runs against real Postgres — single source of truth, no hand-written DDL that could drift from the schema.

## Tests

- `pnpm typecheck` → exit 0.
- `pnpm test` → **20/20 pass** (7 existing trip/billing + 13 new fleet) over a real gRPC client. The existing trip/billing e2e is unchanged: trip → fleet `ctx.call` compatibility is preserved.

The trip/billing services remain in-memory for now (later phases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FleetService server-streaming `ListVehicles` with cursor pagination and optional availability filtering
  * Added `ReserveVehicle` and `ReleaseVehicle` operations
  * Vehicle data now includes lifecycle `status` and optional `location` coordinates
  * FleetService is now persisted via Postgres (with a local Docker setup)
* **Documentation**
  * Expanded README with persistence-backed e2e details, migration/seed commands, and layout overview
* **Tests**
  * Added end-to-end FleetService tests using an in-process Postgres-like database
* **Chores**
  * Added Docker Compose stack plus Drizzle migration/seed tooling and DB configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->