### PR TITLE
feat(hris): back DirectoryService with Drizzle + Postgres (Phase 1)

### DIFF
--- a/hris/README.md
+++ b/hris/README.md
@@ -7,8 +7,10 @@ payroll flow.
 
 Three services and one integration event:
 
-- **`directory.v1.DirectoryService`** — `GetEmployee(id)` → `Employee` (in-memory
-  system of record; `Code.NotFound` for an unknown id). A leaf service.
+- **`directory.v1.DirectoryService`** — `GetEmployee(id)` → `Employee` and
+  `ListEmployees(filter)` → stream of `Employee` (the employee **system of
+  record**, backed by Drizzle ORM + Postgres; `Code.NotFound` for an unknown id).
+  A leaf service — see [Persistence](#persistence-directoryservice--drizzle--postgres).
 - **`timeoff.v1.TimeOffService`** — `RequestLeave(employeeId, days)`. Its handler
   validates the employee with
   `ctx.call("directory.v1.DirectoryService/GetEmployee", …)`, then approves and
@@ -70,23 +72,31 @@ in-memory adapter so the full flow runs broker-free (see
 
 ```
 proto/
-  directory/v1/directory.proto       # DirectoryService.GetEmployee
+  directory/v1/directory.proto       # DirectoryService.GetEmployee + ListEmployees (stream)
   timeoff/v1/timeoff.proto           # TimeOffService.RequestLeave
   payroll/v1/payroll.proto           # PayrollService.GetBalance + LeaveApproved + PayrollEventHandlers
   connectum/events/v1/options.proto  # (connectum.events.v1.event).topic option
 buf.gen.yaml                         # protoc-gen-es + protoc-gen-connectum-catalog (strategy: all)
 src/
-  services/directoryService.ts       # leaf service (in-memory)
+  db/schema.ts                       # Drizzle: employees table + EmployeeStatus const
+  db/client.ts                       # Db type + createDb() (DATABASE_URL, postgres.js)
+  db/seed.ts                         # SEED_EMPLOYEES (org chart) + seedEmployees()
+  services/directoryService.ts       # createDirectoryService(db) — Drizzle-backed leaf service
   services/timeOffService.ts         # ctx.call validation + publishes LeaveApproved
   services/payrollService.ts         # GetBalance + LeaveApproved subscriber route
   topology.ts                        # env → enabledServices + remoteResolver
   events.ts                          # LEAVE_APPROVED_TOPIC constant (publisher/subscriber match)
   eventBus.ts                        # one bus per process; payroll subscribes only when local
-  server.ts                          # buildServer() — same code, both topologies
+  server.ts                          # buildServer() — same code, both topologies + db DI
   index.ts                           # env-driven entry point
+drizzle/                             # generated SQL migrations (single source of truth)
+drizzle.config.ts                    # drizzle-kit config (schema → migrations / push)
 gen/                                 # generated (buf): *_pb.ts + catalog.gen.ts
-tests/e2e/e2e.test.ts                # monolith e2e — in-process, no broker
-docker-compose.yml                   # mono + split profiles + NATS (config only)
+tests/
+  helpers/db.ts                      # PGlite test db (migrate + seed), injected via DI
+  e2e/e2e.test.ts                    # monolith e2e — in-process, no broker (PGlite db)
+  e2e/directory.test.ts              # DirectoryService persistence e2e (real gRPC client)
+docker-compose.yml                   # mono + split profiles + NATS + Postgres (config only)
 Dockerfile                           # one image, role chosen by SERVICES env
 ```
 
@@ -119,6 +129,76 @@ The runtime `serviceCatalog` is passed to `createServer({ catalog })`; the
 (`PayrollEventHandlers`) is mounted via the EventBus, never as an RPC service, so
 it is simply never resolved through `ctx.call`.
 
+## Persistence: DirectoryService + Drizzle + Postgres
+
+DirectoryService is the employee **system of record**, backed by [Drizzle ORM](https://orm.drizzle.team)
+over Postgres (the [`postgres`](https://github.com/porsager/postgres) / postgres.js
+driver). The `employees` table (`src/db/schema.ts`) carries `id`, `name`, `email`,
+`title`, `department`, a self-referencing `manager_id` (nullable — empty for the
+top of the org chart, e.g. the CEO), a lifecycle `status`
+(`active` | `onboarding` | `offboarded`), and `updated_at`. The seed
+(`src/db/seed.ts`) builds a small org chart across two departments — a CEO, two
+managers, and four individual contributors — so the filters below are meaningful.
+
+The RPC surface demonstrates a realistic data-access layer:
+
+- **`GetEmployee`** — point read; `NOT_FOUND` on an unknown id. Returns the full
+  `Employee` (incl. `manager_id` and `status`). This is the row the TimeOff
+  handler's `ctx.call` reads to validate an employee before approving leave.
+- **`ListEmployees`** — **server-streaming** complex query: a SQL
+  `where`/`order by id`/`limit` with **cursor pagination** (the client re-sends
+  the last streamed `Employee.id` as `page_token`), filterable by `department`
+  and/or `manager_id`. The **`manager_id` filter is the org-chart "direct reports
+  of this manager" query** — passing an employee id streams that person's direct
+  reports; the two filters compose (e.g. "Engineering employees reporting to
+  e-002").
+
+The status domain is pinned in code by an `EmployeeStatus` `const` object (proto
+models it as a plain string; a native proto enum is avoided under
+`erasableSyntaxOnly` — see `directory.proto`). `manager_id` is a plain nullable
+text column (no DB-level foreign key), keeping the migration simple.
+
+### Dependency injection — why the tests need no Docker
+
+`buildServer({ db })` injects the database into `createDirectoryService(db)`. In
+production that `db` is a postgres.js client over `DATABASE_URL`; the **e2e tests
+inject a [PGlite](https://pglite.dev) in-process Postgres** through the same
+parameter — Postgres compiled to WASM, no container required. `src/db/schema.ts`
+is the schema source of truth; `pnpm db:generate` derives versioned SQL into
+`drizzle/`. Both the docker-compose flow (`pnpm db:migrate`) and the PGlite test
+migrator apply those **same** generated migrations, then seed the shared directory
+(`src/db/seed.ts`) — so the persistence e2e is fully real but self-contained.
+
+### Run with Postgres (docker-compose)
+
+The `docker-compose.yml` ships a Postgres service (healthcheck) alongside NATS,
+with every app role wired via `DATABASE_URL`:
+
+```bash
+docker compose up -d postgres            # start Postgres only
+
+# Apply migrations and seed the directory (DATABASE_URL points at the compose Postgres):
+export DATABASE_URL=postgresql://hris:hris@localhost:5432/hris
+pnpm db:migrate                          # apply drizzle/ migrations → employees table
+pnpm db:seed                             # seed the demo org chart
+
+docker compose --profile mono up         # monolith on :5000 against Postgres + NATS
+```
+
+Schema/migration scripts:
+
+| Command           | Purpose                                                              |
+| ----------------- | ------------------------------------------------------------------- |
+| `pnpm db:generate`| Generate versioned SQL migrations from `src/db/schema.ts` → `drizzle/` |
+| `pnpm db:migrate` | Apply the `drizzle/` migrations to the Postgres at `DATABASE_URL` (same files the test migrator applies) |
+| `pnpm db:push`    | Dev convenience: diff-sync `schema.ts` to the DB without migrations  |
+| `pnpm db:seed`    | Seed the demo org chart (drops + inserts `src/db/seed.ts`)          |
+
+> `pnpm start` / `pnpm dev` now require `DATABASE_URL` (DirectoryService opens its
+> connection lazily on the first query; every role constructs the client, but
+> only the role mounting the directory ever queries). The e2e tests do **not** —
+> they inject PGlite.
+
 ## Run it
 
 Requires Node.js >= 25.2.0 (native TypeScript) and pnpm >= 10.
@@ -127,9 +207,15 @@ Requires Node.js >= 25.2.0 (native TypeScript) and pnpm >= 10.
 pnpm install
 
 pnpm build:proto   # buf generate → gen/ (incl. catalog.gen.ts with all 3 services)
+pnpm db:generate   # drizzle-kit → drizzle/ SQL migration (the PGlite test migrator applies it)
 pnpm typecheck     # ctx.call is typed by the generated catalog
-pnpm test          # monolith e2e: ctx.call validation + event-driven balance decrement
+pnpm test          # e2e: ctx.call validation + event-driven balance decrement + directory persistence
 ```
+
+The `drizzle/` migrations are committed and are the single source of truth: the
+e2e PGlite db and `pnpm db:migrate` apply the exact same files, so a green test
+run exercises the real schema. See
+[Persistence](#persistence-directoryservice--drizzle--postgres) for Postgres.
 
 ### Monolith (one process, requires NATS)
 
@@ -165,13 +251,26 @@ PORT=5003 SERVICES=payroll.v1.PayrollService node src/index.ts
 
 ## Testing note
 
-The e2e suite (`tests/e2e/e2e.test.ts`) runs the **monolith** with an in-memory
-EventBus adapter — no Docker, no NATS. Because the in-memory adapter delivers
+The e2e suite runs the **monolith** with an in-memory EventBus adapter and a
+PGlite (in-process Postgres) database injected via `buildServer({ db })` — no
+Docker, no NATS, no Postgres container. Because the in-memory adapter delivers
 synchronously, the `LeaveApproved` event has already decremented the payroll
 balance by the time `RequestLeave` resolves, so the assertion needs no polling.
 The cross-service validation path (`ctx.call` → `Code.NotFound` for an unknown
-employee) needs no broker at all. The split topology shares this exact handler
-code and is exercised via `docker-compose.yml`.
+employee) needs no broker at all.
+
+Two test files share the same PGlite setup (`tests/helpers/db.ts`, which migrates
++ seeds the directory):
+
+- `tests/e2e/e2e.test.ts` — the monolith flow (gateway `ctx.call` validation +
+  event-driven balance decrement) over the injected db and bus.
+- `tests/e2e/directory.test.ts` — the full DirectoryService persistence surface
+  over a **real gRPC client**: `GetEmployee` (incl. `NOT_FOUND`), streaming
+  `ListEmployees` with the `department` and org-chart `manager_id` filters, and
+  cursor pagination.
+
+The split topology shares this exact handler code and is exercised via
+`docker-compose.yml`.
 
 ## Key points
 
@@ -184,6 +283,11 @@ code and is exercised via `docker-compose.yml`.
   subscribes. One bus instance in the monolith, one bus per process in the split
   deployment; both use the NATS adapter at runtime. The e2e swaps in an in-memory
   adapter to run the flow broker-free.
+- **Persistence via DI** — DirectoryService is backed by Drizzle + Postgres,
+  injected through `buildServer({ db })`. Production uses postgres.js over
+  `DATABASE_URL`; tests inject PGlite so the persistence e2e runs without Docker.
+  The committed `drizzle/` migrations are the single source of truth both paths
+  apply.
 - **`enabledServices: undefined` vs `[]`** — monolith must pass `undefined`
   (mount everything); an empty array would mount nothing. `topology.ts` handles
   the unset/`*` → `undefined` mapping.

--- a/hris/README.md
+++ b/hris/README.md
@@ -120,7 +120,9 @@ declare module "@connectum/core" {
     "payroll.v1.PayrollEventHandlers/OnLeaveApproved": { request: LeaveApproved; response: Empty };
     "timeoff.v1.TimeOffService/RequestLeave": { request: RequestLeaveRequest; response: RequestLeaveResponse };
   }
-  interface ConnectumStreamMap {}
+  interface ConnectumStreamMap {
+    "directory.v1.DirectoryService/ListEmployees": { request: ListEmployeesRequest; response: Employee; kind: "server-stream" };
+  }
 }
 ```
 
@@ -229,7 +231,7 @@ docker compose --profile mono up    # mono process + NATS
 Or directly, against a running NATS broker:
 
 ```bash
-NATS_URL=nats://localhost:4222 pnpm start   # SERVICES unset → all services local
+DATABASE_URL=postgresql://hris:hris@localhost:5432/hris NATS_URL=nats://localhost:4222 pnpm start
 ```
 
 ### Microservices (split, requires NATS)
@@ -244,9 +246,9 @@ docker compose --profile split up   # directory + timeoff + payroll + NATS
 Or run roles directly (a NATS broker on `NATS_URL` is required for the event flow):
 
 ```bash
-PORT=5001 SERVICES=directory.v1.DirectoryService node src/index.ts
-PORT=5002 SERVICES=timeoff.v1.TimeOffService DIRECTORY_ADDR=http://localhost:5001 node src/index.ts
-PORT=5003 SERVICES=payroll.v1.PayrollService node src/index.ts
+DATABASE_URL=postgresql://hris:hris@localhost:5432/hris PORT=5001 SERVICES=directory.v1.DirectoryService node src/index.ts
+DATABASE_URL=postgresql://hris:hris@localhost:5432/hris PORT=5002 SERVICES=timeoff.v1.TimeOffService DIRECTORY_ADDR=http://localhost:5001 node src/index.ts
+DATABASE_URL=postgresql://hris:hris@localhost:5432/hris PORT=5003 SERVICES=payroll.v1.PayrollService node src/index.ts
 ```
 
 ## Testing note

--- a/hris/docker-compose.yml
+++ b/hris/docker-compose.yml
@@ -1,13 +1,25 @@
 # Two topologies from ONE image, selected by the `SERVICES` env and a compose
 # profile. Config only — not part of the automated test run (the e2e suite runs
-# the monolith in-process with an in-memory bus; see tests/e2e).
+# the monolith in-process with an in-memory bus and a PGlite Postgres; see
+# tests/e2e).
 #
 #   docker compose --profile mono  up    # all services in one process
 #   docker compose --profile split up    # directory + timeoff + payroll split
 #
-# Both profiles share the same `nats` broker. The split profile shows the headline:
-# identical handler code, three processes, ctx.call auto-routing across the network
-# and LeaveApproved flowing over NATS to the payroll role.
+# Both profiles share the same `nats` broker and `postgres` database. The split
+# profile shows the headline: identical handler code, three processes, ctx.call
+# auto-routing across the network and LeaveApproved flowing over NATS to the
+# payroll role.
+#
+# Persistence (Phase 1): DirectoryService is backed by Drizzle ORM over Postgres.
+# Every app role wires DATABASE_URL (postgres.js connects lazily, so the timeoff
+# and payroll roles never actually open it; only DirectoryService queries). First
+# run — apply migrations and seed the directory:
+#
+#   docker compose up -d postgres            # start Postgres only
+#   DATABASE_URL=postgresql://hris:hris@localhost:5432/hris pnpm db:migrate
+#   DATABASE_URL=postgresql://hris:hris@localhost:5432/hris pnpm db:seed
+#   docker compose --profile mono up         # monolith on :5000 against Postgres
 
 services:
   nats:
@@ -26,6 +38,26 @@ services:
       - hris
     profiles: ["mono", "split"]
 
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: hris
+      POSTGRES_PASSWORD: hris
+      POSTGRES_DB: hris
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U hris -d hris"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    networks:
+      - hris
+    profiles: ["mono", "split"]
+
   # ── Topology A: monolith — every service in one process (SERVICES unset) ──
   mono:
     build: .
@@ -35,9 +67,12 @@ services:
     environment:
       - PORT=5000
       - NATS_URL=nats://nats:4222
+      - DATABASE_URL=postgresql://hris:hris@postgres:5432/hris
       # SERVICES unset → monolith (all services local).
     depends_on:
       nats:
+        condition: service_healthy
+      postgres:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:5000/healthz"]
@@ -58,9 +93,12 @@ services:
     environment:
       - PORT=5001
       - NATS_URL=nats://nats:4222
+      - DATABASE_URL=postgresql://hris:hris@postgres:5432/hris
       - SERVICES=directory.v1.DirectoryService
     depends_on:
       nats:
+        condition: service_healthy
+      postgres:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:5001/healthz"]
@@ -80,6 +118,11 @@ services:
     environment:
       - PORT=5002
       - NATS_URL=nats://nats:4222
+      # buildServer() constructs the directory db client for every role, so
+      # DATABASE_URL must be present even though this role never mounts the
+      # directory (postgres.js connects lazily — the connection is never opened
+      # here; DirectoryService is reached over the network via DIRECTORY_ADDR).
+      - DATABASE_URL=postgresql://hris:hris@postgres:5432/hris
       - SERVICES=timeoff.v1.TimeOffService
       # TimeOff calls the directory over the network; the resolver maps the
       # directory typeName to this URL.
@@ -107,6 +150,10 @@ services:
     environment:
       - PORT=5003
       - NATS_URL=nats://nats:4222
+      # buildServer() constructs the directory db client for every role, so
+      # DATABASE_URL must be present even though this role never mounts the
+      # directory (postgres.js connects lazily — the connection is never opened).
+      - DATABASE_URL=postgresql://hris:hris@postgres:5432/hris
       - SERVICES=payroll.v1.PayrollService
     depends_on:
       nats:
@@ -124,3 +171,6 @@ services:
 networks:
   hris:
     driver: bridge
+
+volumes:
+  pgdata:

--- a/hris/drizzle.config.ts
+++ b/hris/drizzle.config.ts
@@ -1,0 +1,23 @@
+/**
+ * drizzle-kit config — generates SQL migrations from `src/db/schema.ts` and
+ * pushes/applies them to the Postgres at `DATABASE_URL`.
+ *
+ *  - `pnpm db:generate` writes versioned SQL into `drizzle/` (committed). Those
+ *    migrations are applied by `pnpm db:migrate` (docker-compose / prod) and by
+ *    the e2e PGlite migrator — same files, one source of truth.
+ *  - `pnpm db:push` is a dev convenience that diff-syncs `schema.ts` to the DB
+ *    without going through the migration files.
+ *
+ * @module drizzle.config
+ */
+
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+    dialect: "postgresql",
+    schema: "./src/db/schema.ts",
+    out: "./drizzle",
+    dbCredentials: {
+        url: process.env.DATABASE_URL ?? "postgresql://hris:hris@localhost:5432/hris",
+    },
+});

--- a/hris/drizzle/0000_neat_maginty.sql
+++ b/hris/drizzle/0000_neat_maginty.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "employees" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"title" text NOT NULL,
+	"department" text NOT NULL,
+	"manager_id" text,
+	"status" text NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/hris/drizzle/meta/0000_snapshot.json
+++ b/hris/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,81 @@
+{
+  "id": "27261cfa-146e-4a8d-b67b-3e29222ba314",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.employees": {
+      "name": "employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/hris/drizzle/meta/_journal.json
+++ b/hris/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1781996332408,
+      "tag": "0000_neat_maginty",
+      "breakpoints": true
+    }
+  ]
+}

--- a/hris/package.json
+++ b/hris/package.json
@@ -15,6 +15,10 @@
     "buf:generate": "buf generate",
     "buf:lint": "buf lint",
     "build:proto": "pnpm run buf:generate",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push",
+    "db:seed": "node src/db/seed.ts",
     "test": "node --test tests/**/*.test.ts",
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down"
@@ -45,13 +49,17 @@
     "@connectum/events-nats": "^1.0.0",
     "@connectum/healthcheck": "^1.0.0",
     "@connectum/interceptors": "^1.0.0",
-    "@connectum/reflection": "^1.0.0"
+    "@connectum/reflection": "^1.0.0",
+    "drizzle-orm": "^0.45.0",
+    "postgres": "^3.4.0"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.65.0",
     "@bufbuild/protoc-gen-es": "^2.11.0",
     "@connectum/protoc-gen-catalog": "^1.0.0",
+    "@electric-sql/pglite": "^0.5.0",
     "@types/node": "^25.2.0",
+    "drizzle-kit": "^0.31.0",
     "typescript": "^5.9.3"
   }
 }

--- a/hris/proto/directory/v1/directory.proto
+++ b/hris/proto/directory/v1/directory.proto
@@ -3,9 +3,22 @@ syntax = "proto3";
 package directory.v1;
 
 // DirectoryService is the employee system of record (leaf service).
+//
+// Persistence (Phase 1): the directory is backed by a real database — Drizzle
+// ORM over Postgres (postgres.js). Tests inject a PGlite in-process Postgres via
+// the same DI the server uses, so no Docker is needed for the e2e.
 service DirectoryService {
   // GetEmployee returns an employee by id, or NOT_FOUND if unknown.
   rpc GetEmployee(GetEmployeeRequest) returns (GetEmployeeResponse) {}
+
+  // ListEmployees streams employees matching a filter, page by page.
+  //
+  // Server-streaming: the handler is a SQL query (`where`/`order by id`/`limit`)
+  // with cursor pagination — the caller re-sends the id of the last streamed
+  // employee as `page_token` to fetch the next page. The optional `department`
+  // and `manager_id` filters narrow the stream; `manager_id` is the org-chart
+  // "direct reports of this manager" query.
+  rpc ListEmployees(ListEmployeesRequest) returns (stream Employee) {}
 }
 
 message GetEmployeeRequest {
@@ -16,8 +29,36 @@ message GetEmployeeResponse {
   Employee employee = 1;
 }
 
+message ListEmployeesRequest {
+  // Optional department filter. Empty = no department filter (all departments).
+  string department = 1;
+  // Optional manager filter — the org-chart "direct reports of this manager"
+  // query. Empty = no manager filter. Set it to an employee id to stream that
+  // person's direct reports.
+  string manager_id = 2;
+  // Max employees per page. Server clamps to a sane default/max when 0 or large.
+  int32 page_size = 3;
+  // Cursor: the id of the last employee from the previous page. Empty = first
+  // page. The stream itself carries no token, so the client derives the cursor
+  // from the last streamed Employee.id.
+  string page_token = 4;
+}
+
 message Employee {
   string id = 1;
   string name = 2;
   string department = 3;
+  // Work email address.
+  string email = 4;
+  // Job title (e.g. "Staff Engineer").
+  string title = 5;
+  // The id of this employee's manager, or empty for the top of the org chart
+  // (e.g. the CEO). Self-referencing within the directory.
+  string manager_id = 6;
+  // Employment lifecycle state: "active" | "onboarding" | "offboarded". Modeled
+  // as a string (not a proto enum) so the generated TypeScript stays erasable —
+  // this example's tsconfig sets `erasableSyntaxOnly`, which rejects the native
+  // `enum` that protoc-gen-es emits. The string domain is pinned in code via a
+  // `const` object (see src/db/schema.ts EmployeeStatus).
+  string status = 7;
 }

--- a/hris/src/db/client.ts
+++ b/hris/src/db/client.ts
@@ -1,0 +1,43 @@
+/**
+ * Drizzle client factory — the app's Postgres connection.
+ *
+ * Production/dev connect over postgres.js to `DATABASE_URL` (the docker-compose
+ * Postgres). The service does NOT import this directly: `buildServer` injects a
+ * `Db` into `createDirectoryService`, so tests can pass a PGlite-backed Drizzle
+ * db (an in-process Postgres) instead — no Docker needed for the e2e.
+ *
+ * The exported {@link Db} type is the common supertype of BOTH drivers'
+ * databases (postgres.js and PGlite both extend `PgDatabase`), so either can be
+ * injected wherever a `Db` is expected.
+ *
+ * @module db/client
+ */
+
+import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
+import { drizzle } from "drizzle-orm/postgres-js";
+import * as schema from "#db/schema.ts";
+
+/**
+ * Driver-agnostic Drizzle database type bound to the app schema.
+ *
+ * Both `drizzle-orm/postgres-js` and `drizzle-orm/pglite` return subclasses of
+ * `PgDatabase`, so typing against the base lets the test inject a PGlite db and
+ * the server inject a postgres.js db through the same `Db` parameter.
+ */
+export type Db = PgDatabase<PgQueryResultHKT, typeof schema>;
+
+/**
+ * Create a Drizzle client over postgres.js from a connection URL.
+ *
+ * postgres.js connects lazily (no socket is opened until the first query), so
+ * constructing this in monolith/test mode where the directory db is overridden
+ * is harmless — the default connection is never used.
+ *
+ * @param url - Postgres connection string; defaults to `DATABASE_URL`.
+ */
+export function createDb(url: string | undefined = process.env.DATABASE_URL): Db {
+    if (url === undefined || url === "") {
+        throw new Error("DATABASE_URL is not set — cannot create the directory database client. " + "Set DATABASE_URL (see docker-compose.yml) or inject a Db (tests use PGlite).");
+    }
+    return drizzle(url, { schema });
+}

--- a/hris/src/db/schema.ts
+++ b/hris/src/db/schema.ts
@@ -1,0 +1,64 @@
+/**
+ * Drizzle schema — the directory's `employees` table (Phase 1 persistence).
+ *
+ * DirectoryService is the only service backed by a real database. The table is
+ * the employee system of record: a row per employee with their name, work
+ * email, job title, department, the id of their manager (an org-chart edge),
+ * employment lifecycle `status`, and an `updatedAt` audit column.
+ *
+ * `status` is a free-text column whose domain is pinned in code by
+ * {@link EmployeeStatus} (proto models it as a plain string; see directory.proto
+ * for why a native proto enum is avoided under `erasableSyntaxOnly`).
+ *
+ * `managerId` is a plain nullable text column that references another row's
+ * `id` (the CEO has `managerId = null`). It is intentionally modeled WITHOUT a
+ * DB-level foreign-key constraint, to keep the generated migration simple — the
+ * org chart is a self-referencing edge enforced by the seed data, not by the DB.
+ *
+ * @module db/schema
+ */
+
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+/**
+ * Employment lifecycle states. A `const` object (ADR-001: no `enum`) — the
+ * string domain stored in {@link employees}.`status`.
+ */
+export const EmployeeStatus = {
+    ACTIVE: "active",
+    ONBOARDING: "onboarding",
+    OFFBOARDED: "offboarded",
+} as const;
+
+/** One of the {@link EmployeeStatus} string values. */
+export type EmployeeStatus = (typeof EmployeeStatus)[keyof typeof EmployeeStatus];
+
+/**
+ * `employees` — the directory system of record.
+ *
+ *  - `id`         text primary key (e.g. `e-001`).
+ *  - `name`       full name.
+ *  - `email`      work email address.
+ *  - `title`      job title (e.g. "Staff Engineer").
+ *  - `department` department name.
+ *  - `managerId`  the id of this employee's manager (nullable — null for the top
+ *                 of the org chart, e.g. the CEO). A plain text column, NOT a
+ *                 DB-level FK, so the migration stays simple.
+ *  - `status`     {@link EmployeeStatus} string.
+ *  - `updatedAt`  last mutation timestamp (defaults to now()).
+ */
+export const employees = pgTable("employees", {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    email: text("email").notNull(),
+    title: text("title").notNull(),
+    department: text("department").notNull(),
+    managerId: text("manager_id"),
+    status: text("status").notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
+/** A selected `employees` row. */
+export type EmployeeRow = typeof employees.$inferSelect;
+/** An insertable `employees` row. */
+export type NewEmployeeRow = typeof employees.$inferInsert;

--- a/hris/src/db/seed.ts
+++ b/hris/src/db/seed.ts
@@ -1,0 +1,66 @@
+/**
+ * Seed data + seeding routine for the directory `employees` table.
+ *
+ * The first three rows reproduce the original in-memory directory so the
+ * existing time-off / payroll flows keep working unchanged:
+ *   - e-001 Ada Lovelace       — Engineering, CEO (top of the org chart)
+ *   - e-002 Grace Hopper       — Engineering, manager
+ *   - e-003 Katherine Johnson  — Finance, manager
+ * (their ids and names are read by the TimeOff → Directory `ctx.call` validation
+ * path and the gRPC RequestLeave e2e, so they must stay present.)
+ *
+ * The remaining rows build a small org chart across TWO departments so the
+ * `manager_id` (org-chart "direct reports") and `department` filters of
+ * ListEmployees are meaningfully testable:
+ *
+ *   e-001 Ada Lovelace (CEO, Engineering, manager=∅)
+ *   ├── e-002 Grace Hopper (Engineering manager)
+ *   │   ├── e-004 Alan Turing       (Engineering IC)
+ *   │   └── e-005 Margaret Hamilton (Engineering IC, onboarding)
+ *   └── e-003 Katherine Johnson (Finance manager)
+ *       ├── e-006 Dorothy Vaughan  (Finance IC)
+ *       └── e-007 Mary Jackson     (Finance IC)
+ *
+ * `seedEmployees(db)` is idempotent-ish for demos: it deletes existing rows then
+ * inserts the seed set, so re-running (`pnpm db:seed`) or re-seeding between
+ * tests yields a known state. Reused by both the CLI script (bottom of file) and
+ * the e2e test helper.
+ *
+ * @module db/seed
+ */
+
+import { EmployeeStatus, employees } from "#db/schema.ts";
+import type { Db } from "#db/client.ts";
+import type { NewEmployeeRow } from "#db/schema.ts";
+
+/** The demo directory — a CEO, two managers, and four individual contributors. */
+export const SEED_EMPLOYEES: ReadonlyArray<NewEmployeeRow> = [
+    { id: "e-001", name: "Ada Lovelace", email: "ada@example.com", title: "Chief Executive Officer", department: "Engineering", managerId: null, status: EmployeeStatus.ACTIVE },
+    { id: "e-002", name: "Grace Hopper", email: "grace@example.com", title: "Engineering Manager", department: "Engineering", managerId: "e-001", status: EmployeeStatus.ACTIVE },
+    { id: "e-003", name: "Katherine Johnson", email: "katherine@example.com", title: "Finance Manager", department: "Finance", managerId: "e-001", status: EmployeeStatus.ACTIVE },
+    { id: "e-004", name: "Alan Turing", email: "alan@example.com", title: "Staff Engineer", department: "Engineering", managerId: "e-002", status: EmployeeStatus.ACTIVE },
+    { id: "e-005", name: "Margaret Hamilton", email: "margaret@example.com", title: "Senior Engineer", department: "Engineering", managerId: "e-002", status: EmployeeStatus.ONBOARDING },
+    { id: "e-006", name: "Dorothy Vaughan", email: "dorothy@example.com", title: "Financial Analyst", department: "Finance", managerId: "e-003", status: EmployeeStatus.ACTIVE },
+    { id: "e-007", name: "Mary Jackson", email: "mary@example.com", title: "Financial Analyst", department: "Finance", managerId: "e-003", status: EmployeeStatus.ACTIVE },
+];
+
+/**
+ * Replace the directory with the {@link SEED_EMPLOYEES} set.
+ *
+ * @param db - Drizzle db (postgres.js in prod, PGlite in tests).
+ */
+export async function seedEmployees(db: Db): Promise<void> {
+    await db.delete(employees);
+    await db.insert(employees).values([...SEED_EMPLOYEES]);
+}
+
+// CLI entrypoint: `pnpm db:seed`. Connects over postgres.js to DATABASE_URL,
+// seeds, and exits. Guarded so importing this module (e.g. from the test helper)
+// does NOT open a database connection.
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const { createDb } = await import("#db/client.ts");
+    const db = createDb();
+    await seedEmployees(db);
+    console.log(`Seeded ${SEED_EMPLOYEES.length} employees.`);
+    process.exit(0);
+}

--- a/hris/src/server.ts
+++ b/hris/src/server.ts
@@ -12,6 +12,10 @@
  *  - `remoteResolver` — maps a remote service `typeName` to its endpoint env var.
  *  - the EventBus role — only the payroll process subscribes to LeaveApproved.
  *
+ * Persistence (Phase 1): DirectoryService is backed by Drizzle + Postgres. The
+ * db is injected so tests can pass a PGlite (in-process Postgres) db; production
+ * defaults to a postgres.js client over `DATABASE_URL`.
+ *
  * @module server
  */
 
@@ -23,8 +27,10 @@ import { Healthcheck } from "@connectum/healthcheck";
 import { createDefaultInterceptors } from "@connectum/interceptors";
 import { Reflection } from "@connectum/reflection";
 import { serviceCatalog } from "#gen/catalog.gen.ts";
+import { createDb } from "#db/client.ts";
+import type { Db } from "#db/client.ts";
 import { buildEventBus } from "#eventBus.ts";
-import { directoryService } from "#services/directoryService.ts";
+import { createDirectoryService } from "#services/directoryService.ts";
 import { payrollService } from "#services/payrollService.ts";
 import { makeTimeOffService } from "#services/timeOffService.ts";
 import { resolveTopology } from "#topology.ts";
@@ -42,6 +48,14 @@ export interface BuildServerOptions {
      * Defaults to a bus built from the resolved topology.
      */
     readonly eventBus?: EventBus & EventBusLike;
+    /**
+     * Directory database override. Tests inject a PGlite-backed Drizzle db so the
+     * e2e runs without Docker; defaults to a postgres.js client over
+     * `DATABASE_URL` (see `#db/client.ts`). Injected for EVERY topology that
+     * mounts the directory (including the monolith, where the TimeOff handler's
+     * `ctx.call` to GetEmployee runs in-process).
+     */
+    readonly db?: Db;
 }
 
 /**
@@ -54,6 +68,12 @@ export function buildServer(options: BuildServerOptions = {}): Server {
     const topology = options.topology ?? resolveTopology();
     const port = options.port ?? Number(process.env.PORT ?? 5000);
     const eventBus = options.eventBus ?? buildEventBus({ localTypeNames: topology.localTypeNames });
+
+    // Directory persistence. postgres.js connects lazily, so constructing the
+    // default db is harmless even when the directory isn't mounted locally; the
+    // connection is opened only when DirectoryService actually queries.
+    const db = options.db ?? createDb();
+    const directoryService = createDirectoryService(db);
 
     return createServer({
         // All three definitions are always passed; `enabledServices` decides

--- a/hris/src/services/directoryService.ts
+++ b/hris/src/services/directoryService.ts
@@ -1,9 +1,26 @@
 /**
- * DirectoryService — the employee system of record (a leaf service).
+ * DirectoryService — the employee system of record, now backed by Drizzle +
+ * Postgres.
  *
- * Defined with `defineService`: handlers receive a Connectum `ctx`, but this
- * service makes no cross-service calls of its own. It owns an in-memory employee
- * map and returns `Code.NotFound` for an unknown id.
+ * This is the only persistent service (Phase 1). It is built by a factory,
+ * `createDirectoryService(db)`, so the database is injected: `buildServer`
+ * passes a postgres.js-backed Drizzle db in production, while the e2e injects a
+ * PGlite (in-process Postgres) db through the same parameter — no Docker for
+ * tests.
+ *
+ * Handlers map SQL rows to the `Employee` proto message.
+ *
+ *  - GetEmployee   — point read; NOT_FOUND on unknown id. Returns the full
+ *                    Employee, including the org-chart `managerId` and `status`.
+ *                    Reached by the TimeOff handler via `ctx.call` to validate
+ *                    that an employee exists before approving a leave request.
+ *  - ListEmployees — server-streaming: a `where`/`order by id`/`limit` query
+ *                    with cursor pagination (the caller re-sends the last
+ *                    streamed id as `page_token`), optionally filtered by
+ *                    `department` and/or `managerId` — the latter being the
+ *                    org-chart "direct reports of this manager" query.
+ *
+ * This service makes no cross-service calls of its own (a leaf service).
  *
  * @module services/directoryService
  */
@@ -11,26 +28,78 @@
 import { create } from "@bufbuild/protobuf";
 import { Code, ConnectError } from "@connectrpc/connect";
 import { defineService } from "@connectum/core";
+import type { ServiceDefinition } from "@connectum/core";
+import { and, asc, eq, gt } from "drizzle-orm";
 import { DirectoryService, EmployeeSchema, GetEmployeeResponseSchema } from "#gen/directory/v1/directory_pb.ts";
+import type { Employee } from "#gen/directory/v1/directory_pb.ts";
+import { employees } from "#db/schema.ts";
+import type { Db } from "#db/client.ts";
+import type { EmployeeRow } from "#db/schema.ts";
 
-/** Seed employees (id → [name, department]). */
-const EMPLOYEES: ReadonlyArray<readonly [string, readonly [string, string]]> = [
-    ["e-001", ["Ada Lovelace", "Engineering"]],
-    ["e-002", ["Grace Hopper", "Engineering"]],
-    ["e-003", ["Katherine Johnson", "Finance"]],
-];
+/** Default page size for ListEmployees when the request asks for 0 / negative. */
+const DEFAULT_PAGE_SIZE = 20;
+/** Hard cap on page size so a client cannot stream an unbounded page. */
+const MAX_PAGE_SIZE = 100;
 
-/** Demo employee directory (id → Employee fields). */
-const employees = new Map<string, { name: string; department: string }>(EMPLOYEES.map(([id, [name, department]]) => [id, { name, department }]));
+/**
+ * Map an `employees` row to the wire `Employee` message.
+ *
+ * A null `managerId` (the top of the org chart) maps to an empty string — proto3
+ * scalar strings have no null, and the proto comments document empty as "no
+ * manager".
+ */
+function toEmployee(row: EmployeeRow): Employee {
+    return create(EmployeeSchema, {
+        id: row.id,
+        name: row.name,
+        department: row.department,
+        email: row.email,
+        title: row.title,
+        managerId: row.managerId ?? "",
+        status: row.status,
+    });
+}
 
-export const directoryService = defineService(DirectoryService, {
-    getEmployee: (req) => {
-        const employee = employees.get(req.id);
-        if (employee === undefined) {
-            throw new ConnectError(`No employee with id "${req.id}".`, Code.NotFound);
-        }
-        return create(GetEmployeeResponseSchema, {
-            employee: create(EmployeeSchema, { id: req.id, name: employee.name, department: employee.department }),
-        });
-    },
-});
+/** Clamp a requested page size into `[1, MAX_PAGE_SIZE]`. */
+function clampPageSize(pageSize: number): number {
+    if (pageSize <= 0) return DEFAULT_PAGE_SIZE;
+    return Math.min(pageSize, MAX_PAGE_SIZE);
+}
+
+/**
+ * Build the DirectoryService definition over an injected Drizzle db.
+ *
+ * @param db - Drizzle database (postgres.js in prod, PGlite in tests).
+ */
+export function createDirectoryService(db: Db): ServiceDefinition {
+    return defineService(DirectoryService, {
+        async getEmployee(req) {
+            const rows = await db.select().from(employees).where(eq(employees.id, req.id)).limit(1);
+            const row = rows[0];
+            if (row === undefined) {
+                throw new ConnectError(`No employee with id "${req.id}".`, Code.NotFound);
+            }
+            return create(GetEmployeeResponseSchema, { employee: toEmployee(row) });
+        },
+
+        async *listEmployees(req) {
+            const limit = clampPageSize(req.pageSize);
+
+            // Cursor pagination over a stable `order by id`: the client re-sends
+            // the last streamed id as page_token to fetch the next page. The
+            // department / managerId filters narrow the stream — managerId is the
+            // org-chart "direct reports of this manager" query. An empty filter
+            // string means "no filter" (same convention as page_token).
+            const cursor = req.pageToken !== "" ? gt(employees.id, req.pageToken) : undefined;
+            const departmentFilter = req.department !== "" ? eq(employees.department, req.department) : undefined;
+            const managerFilter = req.managerId !== "" ? eq(employees.managerId, req.managerId) : undefined;
+            const where = and(cursor, departmentFilter, managerFilter);
+
+            const rows = await db.select().from(employees).where(where).orderBy(asc(employees.id)).limit(limit);
+
+            for (const row of rows) {
+                yield toEmployee(row);
+            }
+        },
+    });
+}

--- a/hris/tests/e2e/directory.test.ts
+++ b/hris/tests/e2e/directory.test.ts
@@ -1,0 +1,193 @@
+/**
+ * E2E tests — DirectoryService over Drizzle + PGlite (Phase 1 persistence).
+ *
+ * The directory is the only persistent service: a PGlite in-process Postgres is
+ * migrated + seeded in the test and injected into `buildServer({ db })`, the
+ * same parameter production uses for its postgres.js client. Every assertion
+ * goes through a REAL gRPC client over HTTP/2 (the server runs
+ * `allowHTTP1: false`), exercising the actual wire path — not the db directly.
+ *
+ * Unlike car-sharing's fleet e2e, this suite ALSO injects a `MemoryAdapter`
+ * EventBus: `buildServer` builds a bus for every role and the payroll subscriber
+ * is registered in the monolith, so without an in-memory adapter `server.start()`
+ * would try to connect to NATS (the default adapter) and hang. The bus is not
+ * exercised here — it is injected only so the server starts without a broker.
+ *
+ * Covered:
+ *  - GetEmployee: point read returns the persisted Employee (incl. email, title,
+ *    managerId, status); unknown id → NOT_FOUND.
+ *  - ListEmployees (server-streaming): the unfiltered stream returns all seeds in
+ *    id order; the `department` filter narrows to a department; the `manager_id`
+ *    filter is the org-chart "direct reports of this manager" query; cursor
+ *    pagination (page_size + page_token) walks pages; combined filters compose.
+ */
+
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import type { Client } from "@connectrpc/connect";
+import type { Server } from "@connectum/core";
+import { MemoryAdapter } from "@connectum/events";
+import { DirectoryService, GetEmployeeRequestSchema, ListEmployeesRequestSchema } from "#gen/directory/v1/directory_pb.ts";
+import type { Employee } from "#gen/directory/v1/directory_pb.ts";
+import { buildEventBus } from "#eventBus.ts";
+import { buildServer } from "#server.ts";
+import type { Db } from "#db/client.ts";
+import { resolveTopology } from "#topology.ts";
+import { makeTestDb } from "../helpers/db.ts";
+
+/** Drain a server-streaming response into an array. */
+async function collect(stream: AsyncIterable<Employee>): Promise<Employee[]> {
+    const out: Employee[] = [];
+    for await (const e of stream) out.push(e);
+    return out;
+}
+
+describe("E2E: DirectoryService persistence (Drizzle + PGlite, real gRPC client)", () => {
+    let server: Server;
+    let db: Db;
+    let directory: Client<typeof DirectoryService>;
+
+    before(async () => {
+        // Monolith topology, a PGlite-backed Drizzle db (no Docker), and an
+        // in-memory EventBus so the server starts without a NATS broker.
+        const topology = resolveTopology("*");
+        db = await makeTestDb();
+        const eventBus = buildEventBus({ localTypeNames: topology.localTypeNames, adapter: MemoryAdapter() });
+        server = buildServer({ port: 0, topology, eventBus, db });
+        await server.start();
+        const port = server.address?.port ?? 0;
+        directory = createClient(DirectoryService, createGrpcTransport({ baseUrl: `http://localhost:${port}` }));
+    });
+
+    after(async () => {
+        if (server.state === "running") await server.stop();
+    });
+
+    it("GetEmployee returns the persisted employee with all fields", async () => {
+        const res = await directory.getEmployee(create(GetEmployeeRequestSchema, { id: "e-002" }));
+        assert.equal(res.employee?.id, "e-002");
+        assert.equal(res.employee?.name, "Grace Hopper");
+        assert.equal(res.employee?.department, "Engineering");
+        assert.equal(res.employee?.email, "grace@example.com");
+        assert.equal(res.employee?.title, "Engineering Manager");
+        assert.equal(res.employee?.managerId, "e-001");
+        assert.equal(res.employee?.status, "active");
+    });
+
+    it("GetEmployee on the CEO returns an empty manager_id (top of the org chart)", async () => {
+        const res = await directory.getEmployee(create(GetEmployeeRequestSchema, { id: "e-001" }));
+        assert.equal(res.employee?.id, "e-001");
+        assert.equal(res.employee?.name, "Ada Lovelace");
+        assert.equal(res.employee?.managerId, "");
+        assert.equal(res.employee?.status, "active");
+    });
+
+    it("GetEmployee surfaces an onboarding status", async () => {
+        const res = await directory.getEmployee(create(GetEmployeeRequestSchema, { id: "e-005" }));
+        assert.equal(res.employee?.id, "e-005");
+        assert.equal(res.employee?.status, "onboarding");
+    });
+
+    it("GetEmployee on an unknown id is NOT_FOUND", async () => {
+        await assert.rejects(
+            directory.getEmployee(create(GetEmployeeRequestSchema, { id: "ghost" })),
+            (err: unknown) => err instanceof ConnectError && err.code === Code.NotFound,
+        );
+    });
+
+    it("ListEmployees streams every seeded employee in id order (no filter)", async () => {
+        const all = await collect(directory.listEmployees(create(ListEmployeesRequestSchema, {})));
+        assert.equal(all.length, 7);
+        assert.deepEqual(
+            all.map((e) => e.id),
+            ["e-001", "e-002", "e-003", "e-004", "e-005", "e-006", "e-007"],
+        );
+    });
+
+    it("ListEmployees filters by department", async () => {
+        const eng = await collect(directory.listEmployees(create(ListEmployeesRequestSchema, { department: "Engineering" })));
+        assert.deepEqual(
+            eng.map((e) => e.id),
+            ["e-001", "e-002", "e-004", "e-005"],
+        );
+        assert.ok(eng.every((e) => e.department === "Engineering"));
+
+        const finance = await collect(directory.listEmployees(create(ListEmployeesRequestSchema, { department: "Finance" })));
+        assert.deepEqual(
+            finance.map((e) => e.id),
+            ["e-003", "e-006", "e-007"],
+        );
+    });
+
+    it("ListEmployees filters by manager_id (org-chart direct reports)", async () => {
+        // Grace Hopper's direct reports.
+        const graceReports = await collect(directory.listEmployees(create(ListEmployeesRequestSchema, { managerId: "e-002" })));
+        assert.deepEqual(
+            graceReports.map((e) => e.id),
+            ["e-004", "e-005"],
+        );
+        assert.ok(graceReports.every((e) => e.managerId === "e-002"));
+
+        // The CEO's direct reports (the two managers).
+        const ceoReports = await collect(directory.listEmployees(create(ListEmployeesRequestSchema, { managerId: "e-001" })));
+        assert.deepEqual(
+            ceoReports.map((e) => e.id),
+            ["e-002", "e-003"],
+        );
+    });
+
+    it("ListEmployees paginates with page_size + page_token (cursor over the stream)", async () => {
+        // Page 1 — first three by id.
+        const page1 = await collect(directory.listEmployees(create(ListEmployeesRequestSchema, { pageSize: 3 })));
+        assert.deepEqual(
+            page1.map((e) => e.id),
+            ["e-001", "e-002", "e-003"],
+        );
+
+        // Page 2 — cursor = last streamed id of page 1.
+        const cursor = page1[page1.length - 1]?.id ?? "";
+        const page2 = await collect(directory.listEmployees(create(ListEmployeesRequestSchema, { pageSize: 3, pageToken: cursor })));
+        assert.deepEqual(
+            page2.map((e) => e.id),
+            ["e-004", "e-005", "e-006"],
+        );
+
+        // Page 3 — the remainder (fewer than page_size).
+        const cursor2 = page2[page2.length - 1]?.id ?? "";
+        const page3 = await collect(directory.listEmployees(create(ListEmployeesRequestSchema, { pageSize: 3, pageToken: cursor2 })));
+        assert.deepEqual(
+            page3.map((e) => e.id),
+            ["e-007"],
+        );
+    });
+
+    it("ListEmployees combines the department and manager_id filters", async () => {
+        // Engineering employees who report directly to Grace Hopper (e-002).
+        const combined = await collect(directory.listEmployees(create(ListEmployeesRequestSchema, { department: "Engineering", managerId: "e-002" })));
+        assert.deepEqual(
+            combined.map((e) => e.id),
+            ["e-004", "e-005"],
+        );
+        assert.ok(combined.every((e) => e.department === "Engineering" && e.managerId === "e-002"));
+    });
+
+    it("ListEmployees combines a filter with cursor pagination", async () => {
+        // Engineering in id order: e-001, e-002, e-004, e-005.
+        const page1 = await collect(directory.listEmployees(create(ListEmployeesRequestSchema, { department: "Engineering", pageSize: 2 })));
+        assert.deepEqual(
+            page1.map((e) => e.id),
+            ["e-001", "e-002"],
+        );
+
+        const cursor = page1[page1.length - 1]?.id ?? "";
+        const page2 = await collect(directory.listEmployees(create(ListEmployeesRequestSchema, { department: "Engineering", pageSize: 2, pageToken: cursor })));
+        // The cursor skips past e-003 (Finance) — the filter + cursor compose.
+        assert.deepEqual(
+            page2.map((e) => e.id),
+            ["e-004", "e-005"],
+        );
+    });
+});

--- a/hris/tests/e2e/e2e.test.ts
+++ b/hris/tests/e2e/e2e.test.ts
@@ -30,6 +30,7 @@ import { buildServer } from "#server.ts";
 import { resetBalances } from "#services/payrollService.ts";
 import { resolveTopology } from "#topology.ts";
 import { MemoryAdapter } from "@connectum/events";
+import { makeTestDb } from "../helpers/db.ts";
 
 describe("E2E: HRIS monolith (in-process, no broker)", () => {
     let server: Server;
@@ -39,10 +40,13 @@ describe("E2E: HRIS monolith (in-process, no broker)", () => {
         // Force monolith topology and an in-memory bus so publish → subscribe →
         // balance-decrement runs entirely in this process. The SAME bus instance
         // is injected into the server so the TimeOff publisher and the Payroll
-        // subscriber share it.
+        // subscriber share it. A PGlite-backed Drizzle db is injected too, so
+        // DirectoryService persists without Docker — the TimeOff handler's
+        // in-process ctx.call to GetEmployee reads from it.
         const topology = resolveTopology("*");
         const eventBus = buildEventBus({ localTypeNames: topology.localTypeNames, adapter: MemoryAdapter() });
-        server = buildServer({ port: 0, topology, eventBus });
+        const db = await makeTestDb();
+        server = buildServer({ port: 0, topology, eventBus, db });
         await server.start();
         const port = server.address?.port ?? 0;
         grpcTimeOff = createClient(TimeOffService, createGrpcTransport({ baseUrl: `http://localhost:${port}` }));

--- a/hris/tests/helpers/db.ts
+++ b/hris/tests/helpers/db.ts
@@ -1,0 +1,45 @@
+/**
+ * Test database helper — an in-process Postgres for the e2e, no Docker.
+ *
+ * Builds a fresh PGlite-backed Drizzle db, applies the SAME drizzle-kit
+ * migrations the app uses against real Postgres (single source of truth — no
+ * hand-written DDL that could drift from `src/db/schema.ts`), and seeds it with
+ * the shared {@link seedEmployees} data so the directory matches what the
+ * existing time-off / payroll e2e and the new directory e2e expect.
+ *
+ * The returned `Db` is injected into `buildServer({ db })`, the same parameter
+ * production uses for its postgres.js client.
+ *
+ * @module tests/helpers/db
+ */
+
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
+import { migrate } from "drizzle-orm/pglite/migrator";
+import type { Db } from "#db/client.ts";
+import * as schema from "#db/schema.ts";
+import { seedEmployees } from "#db/seed.ts";
+
+/** Absolute path to the committed drizzle-kit migrations folder. */
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+
+/**
+ * Create a migrated, seeded PGlite-backed Drizzle db for tests.
+ *
+ * Each call spins up an isolated in-memory Postgres, so test files do not share
+ * state. Re-seed within a file (e.g. in `beforeEach`) via {@link reseed} when a
+ * test mutates rows.
+ */
+export async function makeTestDb(): Promise<Db> {
+    const client = new PGlite();
+    const db = drizzle(client, { schema });
+    await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+    await seedEmployees(db);
+    return db;
+}
+
+/** Reset the directory to the seed state (used between tests that mutate rows). */
+export async function reseed(db: Db): Promise<void> {
+    await seedEmployees(db);
+}


### PR DESCRIPTION
## What

Phase 1 of the hris example evolution: replace DirectoryService's in-memory `Map` with a real **Drizzle ORM + Postgres** persistence layer, and add an **org-chart complex query**. Mirrors the car-sharing Phase 1 pattern; the framework stays thin (persistence is an external best-of-breed product wired in via dependency injection).

## Changes

- **Schema** (`src/db/schema.ts`) — `employees` table as the single source of truth. `status` is a string pinned by a `const EmployeeStatus` object (ADR-001: no `enum`), so the generated proto stays erasable under `erasableSyntaxOnly`. `manager_id` is a nullable self-reference (no DB-level FK) that models the org chart.
- **DirectoryService surface** (`src/services/directoryService.ts`), now a factory `createDirectoryService(db)`:
  - `GetEmployee` — point read; `NOT_FOUND` on unknown id. Returns the full `Employee` (the time-off handler reaches it via `ctx.call` to validate an employee before approving leave).
  - `ListEmployees` — **server-streaming complex query**: `where` / `order by id` / `limit` with **cursor pagination**, an optional `department` filter, and an optional `manager_id` filter — the org-chart **"direct reports of this manager"** query.
  - `Employee` is extended additively (`email`, `title`, `manager_id`, `status`); field numbers 1–3 are preserved.
- **Dependency injection** — `buildServer({ db })` injects the database into `createDirectoryService(db)`. Production uses a postgres.js client over `DATABASE_URL`; the e2e injects **PGlite** (in-process Postgres) through the same parameter, so tests need no Docker. The existing EventBus wiring is unchanged.
- **Tooling** — `docker-compose.yml` gains a `postgres` service alongside `nats`, plus `drizzle.config.ts`, generated `drizzle/` migrations, and `db:generate` / `db:migrate` / `db:push` / `db:seed` scripts.

## Migration integrity

The e2e test migrator (`tests/helpers/db.ts`) applies the **same committed `drizzle/` migrations** that `pnpm db:migrate` runs against real Postgres — single source of truth, no hand-written DDL.

## Tests

- `pnpm buf:generate` / `pnpm buf:lint` / `pnpm typecheck` → exit 0.
- `pnpm test` → **16/16 pass**: new directory e2e over a real gRPC client (point read, org-chart `manager_id` filter, department filter, cursor pagination, combined filters) plus the existing time-off / payroll e2e — unchanged, with the time-off → directory `ctx.call` validation path preserved (`e-001`..`e-003` kept in the seed).

The payroll / time-off services remain in-memory for now (later phases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3