### PR TITLE
feat(car-sharing): durable trip saga with Temporal (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Ready-to-run examples demonstrating Connectum features — from a one-service [q
 | [interceptors/jwt](interceptors/jwt/) | Client-side JWT interceptor | Bearer token injection, `createAddTokenInterceptor()` | Ready |
 | [with-custom-interceptor](with-custom-interceptor/) | Echo service with custom interceptors | API key auth, rate limiting | Ready |
 | [hris](hris/) | Monolith **or** microservices — one codebase | `defineService` + catalog + `ctx.call` (in-process vs remote by env) + EventBus saga | Ready |
-| [car-sharing](car-sharing/) | Enterprise deploy — Kubernetes + Istio | Split microservices + JWT/proto authz gateway + OpenTelemetry; k8s/Istio manifests (mTLS, canary) | Ready |
+| [car-sharing](car-sharing/) | Enterprise deploy — Kubernetes + Istio | Split microservices + JWT/proto authz gateway + OpenTelemetry; durable trip saga with Temporal; k8s/Istio manifests (mTLS, canary) | Ready |
 | [with-events-kafka](with-events-kafka/) | EventBus with Kafka | Event-driven microservices, consumer groups | Ready |
 | [with-events-redpanda](with-events-redpanda/) | EventBus with Redpanda | Saga choreography, custom topics, Redpanda Console | Ready |
 | [with-events-valkey](with-events-valkey/) | EventBus with Valkey (Redis) | Redis Streams adapter, lightweight event bus | Ready |
@@ -71,14 +71,18 @@ grpcurl -plaintext -d '{"name": "World"}' localhost:5000 greeter.v1.GreeterServi
 ## Enterprise deployment
 
 The [car-sharing](car-sharing/) example demonstrates a split-microservices
-deployment with a JWT/proto-authz gateway and OpenTelemetry, plus the manifests
-to run it:
+deployment with a JWT/proto-authz gateway, a durable trip saga with
+[Temporal](https://temporal.io), and OpenTelemetry, plus the manifests to run
+it:
 
 - **Kubernetes** — per-service Deployment / Service / HPA / RBAC, single
   role-selectable image (`SERVICES` env), `perServiceEnvResolver` wiring
   cross-service `ctx.call` across pods.
 - **Istio** — PeerAuthentication mTLS (STRICT), AuthorizationPolicy, VirtualService /
   DestinationRule, a canary example.
+- **Temporal** — durable `TripWorkflow` saga (reserve → charge → settle) with
+  automatic LIFO compensation; a separate worker process keeps the RPC roles
+  build-free.
 
 See [car-sharing/README.md](car-sharing/README.md) for details.
 

--- a/car-sharing/README.md
+++ b/car-sharing/README.md
@@ -19,20 +19,20 @@ wiring.
 
 | Service                   | Role            | RPC                          | Auth                                  |
 | ------------------------- | --------------- | ---------------------------- | ------------------------------------- |
-| `trips.v1.TripService`    | edge / gateway  | `StartTrip(userId, vehicle)` | JWT required (proto `default_policy: allow`) |
+| `trips.v1.TripService`    | edge / gateway  | `StartTrip(userId, vehicle)`, `GetTrip(tripId)` | JWT required (proto `default_policy: allow`); `RecordTrip`/`EndTrip` method-level `public` (internal, worker-only) |
 | `fleet.v1.FleetService`   | internal leaf   | `GetVehicle`, `ListVehicles` (stream), `ReserveVehicle`, `ReleaseVehicle` | `public` (proto `service_auth.public`) |
-| `billing.v1.BillingService` | internal leaf | `OpenTab(tripId)`            | `public`                              |
+| `billing.v1.BillingService` | internal leaf | `OpenTab`, `AddCharge`, `Settle`, `VoidTab`, `RefundCharge` | `public`                              |
 
 `FleetService` is backed by a real database (Drizzle ORM + Postgres) — see
 [Persistence](#persistence-fleetservice--drizzle--postgres). The trip/billing
-services remain in-memory for now (later phases).
+services remain in-memory (durable state lives in Temporal workflow history).
 
-`StartTrip` orchestrates two cross-service calls:
-
-1. `ctx.call("fleet.v1.FleetService/GetVehicle", …)` — unavailable vehicle →
-   `FAILED_PRECONDITION`; unknown id → `NOT_FOUND` (propagated from fleet).
-2. `ctx.call("billing.v1.BillingService/OpenTab", …)` — opens the tab once the
-   trip starts.
+`StartTrip` does a **synchronous availability pre-check** (`ctx.call` to
+`FleetService/GetVehicle`) — unavailable vehicle → `FAILED_PRECONDITION`;
+unknown id → `NOT_FOUND` (propagated from fleet) — then **starts a durable
+`TripWorkflow`** and returns immediately with `{ trip, workflow_id }`. Live
+status is read via `GetTrip`. See [Phase 2](#phase-2--durable-saga-with-temporal)
+for the full saga.
 
 ## Architecture
 
@@ -58,8 +58,10 @@ flowchart TB
 
     client -->|"/trips.v1.TripService/StartTrip"| ingress
     ingress -->|"AuthorizationPolicy:<br/>ingress SA only"| tripsApp
-    tripsApp -->|"ctx.call GetVehicle<br/>(FLEET_ADDR)"| fleetApp
-    tripsApp -->|"ctx.call OpenTab<br/>(BILLING_ADDR)"| billingApp
+    tripsApp -->|"ctx.call GetVehicle<br/>(pre-check, FLEET_ADDR)"| fleetApp
+    tripsApp -.->|"starts TripWorkflow<br/>(Temporal client)"| temporal[(Temporal<br/>cluster)]
+    temporal -->|"worker activities<br/>(ReserveVehicle, RecordTrip…)"| fleetApp
+    temporal -->|"worker activities<br/>(OpenTab, AddCharge, Settle…)"| billingApp
 
     fleetApp -. "AuthorizationPolicy:<br/>trips SA only" .-> tripsApp
     billingApp -. "AuthorizationPolicy:<br/>trips SA only" .-> tripsApp
@@ -113,13 +115,15 @@ pnpm start            # monolith on :5000 (SERVICES unset)
 ```
 
 The e2e suite runs the whole app in one process and asserts: the happy
-`StartTrip` path (both `ctx.call`s), `FAILED_PRECONDITION` for an unavailable
-vehicle, `NOT_FOUND` propagated from fleet, the gateway rejecting unauthenticated
-/ invalid-token requests while the public fleet service is reachable without a
-token (`tests/e2e/e2e.test.ts`), and the full FleetService persistence surface —
+`StartTrip` path (GetVehicle pre-check + workflow start returning `{ trip,
+workflow_id }`), `FAILED_PRECONDITION` for an unavailable vehicle, `NOT_FOUND`
+propagated from fleet, the gateway rejecting unauthenticated / invalid-token
+requests while the public fleet service is reachable without a token
+(`tests/e2e/e2e.test.ts`), and the full FleetService persistence surface —
 `GetVehicle`, streaming `ListVehicles` with filter + cursor pagination,
 `ReserveVehicle`/`ReleaseVehicle` — over a real gRPC client
-(`tests/e2e/fleet.test.ts`).
+(`tests/e2e/fleet.test.ts`). The saga itself (orchestration order +
+compensations) is covered by `tests/workflow/` and `tests/activity/`.
 
 ## Persistence: FleetService + Drizzle + Postgres
 
@@ -384,21 +388,25 @@ car-sharing/
 ├── src/
 │   ├── db/                     Drizzle: schema.ts, client.ts (Db DI), seed.ts
 │   ├── services/               fleetService (Drizzle), billingService, tripService
+│   ├── temporal/               TripWorkflow, activities, workflowClient, clients, config, tripStatus
 │   ├── topology.ts             env → mono/split (SERVICES + perServiceEnvResolver)
 │   ├── auth.ts                 JWT + proto authz interceptors (uniform chain)
 │   ├── observability.ts        env-gated OpenTelemetry wiring
 │   ├── server.ts               buildServer() — services + catalog + interceptors + db
+│   ├── worker.ts               Temporal worker process (bundles workflow via swc; `pnpm worker`)
 │   └── index.ts                entry point (role by SERVICES)
 ├── drizzle/                    generated SQL migrations (single source of truth)
 ├── drizzle.config.ts           drizzle-kit config (schema → migrations / push)
 ├── tests/
 │   ├── helpers/db.ts           PGlite test db (migrate + seed), injected via DI
-│   └── e2e/                     e2e.test.ts (gateway/ctx.call) + fleet.test.ts (persistence)
+│   ├── workflow/               TripWorkflow: forward order + reverse compensation (mocked activities)
+│   ├── activity/               Activity bodies: RPC wiring + compensation idempotency (in-process monolith)
+│   └── e2e/                    e2e.test.ts (gateway/pre-check/auth, stub workflow client) + fleet.test.ts (persistence)
 ├── k8s/                        namespace, rbac, secret, configmap, deployments,
 │                               services, hpa
 ├── istio/                      peer-auth, authz, destination-rule, virtual-service,
 │                               gateway, canary
-├── docker-compose.yml          local monolith + Postgres (healthcheck)
+├── docker-compose.yml          profiles: `mono` (monolith + Postgres), `saga` (roles + worker + Temporal + Postgres)
 ├── Dockerfile                  one multi-stage image, role by env
 ├── buf.yaml / buf.gen.yaml     dual-module (own protos + auth options) + catalog plugin
 ├── package.json / tsconfig.json / pnpm-workspace.yaml

--- a/car-sharing/README.md
+++ b/car-sharing/README.md
@@ -194,6 +194,109 @@ loopback. The framework strips the in-process transport's framing headers
 leak into the outer call's gRPC trailers (which would otherwise be illegal
 HTTP/2). No edge-level error translation is needed.
 
+## Phase 2 — durable saga with Temporal
+
+Phase 1's `StartTrip` did the whole flow inline with `ctx.call`: check the
+vehicle, open the tab, return. That is fine until a step **midway** fails — there
+is no durable record of what already happened and nothing to undo it. Phase 2
+replaces the inline chain with a **durable [Temporal](https://temporal.io)
+workflow** that owns the trip lifecycle and **compensates automatically** when a
+step fails. Connectum stays a thin RPC/contract layer; Temporal is the durable
+brain.
+
+### What moved
+
+`StartTrip` keeps a **synchronous availability pre-check** (a `ctx.call` to
+`FleetService/GetVehicle`) so the **edge error contract is unchanged**: an
+unavailable vehicle is still `FAILED_PRECONDITION`, an unknown one still
+`NOT_FOUND` — both raised **before** any workflow starts. Only after the
+pre-check passes does the handler **start** the durable `TripWorkflow` and return
+immediately with the trip id, an initial `STARTED` status, and the `workflow_id`:
+
+```jsonc
+// StartTrip response (the saga then runs durably in the background)
+{ "trip": { "id": "trip-…", "status": "STARTED" }, "workflowId": "trip-…" }
+```
+
+Live status is read with a new **`GetTrip`** RPC, which issues a Temporal
+**Workflow Query** (`handle.query(getTripStatus)`) against the running workflow,
+falling back to a terminal status (`SETTLED` / `CANCELLED`) once it closes.
+
+### The saga and its compensations
+
+`TripWorkflow` runs the forward steps in order, pushing a compensation onto a
+stack after each side-effecting step; on **any** failure it unwinds the stack in
+reverse (LIFO) and rethrows — the canonical Temporal saga pattern. Each step is
+an **activity** that makes one ConnectRPC call to a role service.
+
+| #   | Forward step (activity → RPC)            | Compensation (activity → RPC)             |
+| --- | ---------------------------------------- | ----------------------------------------- |
+| 1   | `reserveVehicle` → `FleetService/ReserveVehicle` | `releaseVehicle` → `FleetService/ReleaseVehicle` |
+| 2   | `recordTrip` → `TripService/RecordTrip`  | `markTripCancelled` → `TripService/EndTrip` (CANCELLED) |
+| 3   | _the drive_ (a workflow timer)           | —                                         |
+| 4   | `endTrip` → `TripService/EndTrip` (ENDED) | _(none — rollback reuses step 2)_         |
+| 5   | `openTab` → `BillingService/OpenTab`     | `voidTab` → `BillingService/VoidTab`      |
+| 6   | `addCharge` → `BillingService/AddCharge` | `refundCharge` → `BillingService/RefundCharge` |
+| 7   | `settle` → `BillingService/Settle`       | _(terminal — none)_                       |
+
+So if **settle** fails, the unwind runs `refundCharge → voidTab →
+markTripCancelled → releaseVehicle`; if **endTrip** fails (before any billing),
+it runs only `markTripCancelled → releaseVehicle`. Every compensation is
+**idempotent** (release on a free vehicle, void on a void tab, refund on a
+refunded charge are all no-op successes), because Temporal may run a compensation
+after a forward step partially applied. Step 1's availability failure is a
+**non-retryable** `ApplicationFailure`, so the workflow fails fast with nothing
+to undo.
+
+### Processes
+
+The native Temporal worker (the Rust core-bridge addon + the on-the-fly workflow
+bundler) is **confined to one new process**, so the existing RPC roles keep their
+no-build, native-TS run model:
+
+| Process                | Entry              | Temporal package        |
+| ---------------------- | ------------------ | ----------------------- |
+| RPC roles (trips/fleet/billing/monolith) | `node src/index.ts` | `@temporalio/client` (pure JS) — gateway only |
+| **Worker** (hosts the workflow + activities) | `node src/worker.ts` (`pnpm worker`) | `@temporalio/worker` (native) |
+
+The gateway's Temporal client is **lazy** (`Connection.lazy` — no socket until
+the first start/query), so the server starts and the **pre-check error paths run
+without a live Temporal server**. Internal `RecordTrip` / `EndTrip` are
+method-level `public` in proto so the worker's tokenless ConnectRPC clients pass
+the gateway auth chain (fleet/billing are already service-level `public`).
+
+### Run it and watch the saga
+
+```bash
+docker compose up -d postgres
+DATABASE_URL=postgresql://car_sharing:car_sharing@localhost:5432/car_sharing pnpm db:migrate
+DATABASE_URL=postgresql://car_sharing:car_sharing@localhost:5432/car_sharing pnpm db:seed
+docker compose --profile saga up --build   # roles + worker + Temporal + Web UI
+open http://localhost:8088                  # Temporal Web UI
+```
+
+Start a trip against the `trips` role (gRPC `:5002`) and watch `TripWorkflow`
+walk reserve → record → end → openTab → addCharge → settle in the Web UI. Stop
+the `billing` role mid-run to watch the compensations unwind in reverse.
+
+### Tests — dockerless
+
+The saga is covered without Docker or a Temporal cluster:
+
+- `tests/workflow/tripWorkflow.test.ts` — the **real workflow** with **mocked
+  activities** on Temporal's time-skipping test environment (an embedded test
+  server; the binary is downloaded and cached on first run only). It asserts the
+  forward order on success and the **reverse compensation order** on a `settle`
+  failure and an `endTrip` failure.
+- `tests/activity/activities.test.ts` — the **real activity bodies** (via
+  `MockActivityEnvironment`) against an **in-process Connectum monolith**
+  (`buildServer({ port: 0 })`, PGlite fleet), asserting the activity↔RPC wiring,
+  the moved billing side effects, and compensation **idempotency**.
+- `tests/e2e/e2e.test.ts` — the gateway with a **stub** Temporal client: the
+  pre-check `FAILED_PRECONDITION` / `NOT_FOUND` paths, the auth paths, and that a
+  valid `StartTrip` returns `{ trip, workflow_id }` and starts exactly one
+  workflow keyed by the trip id.
+
 ## Build the image
 
 ```bash

--- a/car-sharing/docker-compose.yml
+++ b/car-sharing/docker-compose.yml
@@ -1,21 +1,39 @@
-# Local monolith stack — the car-sharing app + its Postgres (Phase 1 persistence).
+# Two stacks from one image, selected by compose profile. Config only — NOT part
+# of the automated test run (the e2e suite uses an in-process PGlite Postgres and
+# the time-skipping Temporal test server; see tests/).
 #
-# FleetService is backed by Drizzle ORM over Postgres. This compose file brings
-# up Postgres with a healthcheck and runs the app as the monolith (every service
-# in-process, SERVICES unset), wired to the database via DATABASE_URL.
+#   docker compose --profile mono up --build    # Phase 1: monolith + Postgres
+#   docker compose --profile saga up --build     # Phase 2: durable saga on Temporal
 #
-# First run — apply migrations and seed the fleet:
+# ── Phase 1 (mono) ──────────────────────────────────────────────────────────
+# FleetService over Drizzle + Postgres; every service in-process (SERVICES
+# unset). StartTrip needs Temporal, so the `mono` profile is for the fleet /
+# persistence demo; the trip saga lives in the `saga` profile.
 #
-#   docker compose up -d postgres            # start Postgres only
-#   DATABASE_URL=postgresql://car_sharing:car_sharing@localhost:5432/car_sharing \
-#     pnpm db:migrate                        # apply drizzle/ migrations → vehicles table
-#   DATABASE_URL=postgresql://car_sharing:car_sharing@localhost:5432/car_sharing \
-#     pnpm db:seed                           # seed the demo fleet
-#   docker compose up app                    # start the app (monolith on :5000)
+# First run — migrate + seed the fleet:
+#   docker compose up -d postgres
+#   DATABASE_URL=postgresql://car_sharing:car_sharing@localhost:5432/car_sharing pnpm db:migrate
+#   DATABASE_URL=postgresql://car_sharing:car_sharing@localhost:5432/car_sharing pnpm db:seed
+#   docker compose --profile mono up app
 #
-# The e2e tests do NOT need this — they use an in-process PGlite Postgres.
+# ── Phase 2 (saga) ──────────────────────────────────────────────────────────
+# The three RPC roles split (one process each, role by SERVICES), the Temporal
+# WORKER as its own process (`node src/worker.ts`), the Temporal server + Web UI,
+# Temporal's OWN Postgres, and the app Postgres (above) for the fleet. Temporal
+# owns + migrates its schema (auto-setup), so its store is kept SEPARATE from the
+# app db. Run it and watch the saga (and its compensations) in the Web UI:
+#
+#   docker compose up -d postgres
+#   DATABASE_URL=postgresql://car_sharing:car_sharing@localhost:5432/car_sharing pnpm db:migrate
+#   DATABASE_URL=postgresql://car_sharing:car_sharing@localhost:5432/car_sharing pnpm db:seed
+#   docker compose --profile saga up --build
+#   open http://localhost:8088   # Temporal Web UI
+#   # Start a trip against the trips role (gRPC :5002, e.g. via grpcurl) and watch
+#   # TripWorkflow reserve → record → end → openTab → addCharge → settle. Stop the
+#   # billing role mid-run to watch the compensations unwind in reverse.
 
 services:
+  # ── App Postgres for the fleet (shared by both profiles) ───────────────────
   postgres:
     image: postgres:17-alpine
     environment:
@@ -32,7 +50,11 @@ services:
       timeout: 3s
       retries: 10
       start_period: 5s
+    networks:
+      - car-sharing
+    profiles: ["mono", "saga"]
 
+  # ── Phase 1: monolith — every service in-process (SERVICES unset) ──────────
   app:
     build: .
     image: car-sharing:local
@@ -46,6 +68,182 @@ services:
       DATABASE_URL: postgresql://car_sharing:car_sharing@postgres:5432/car_sharing
     ports:
       - "5000:5000"
+    networks:
+      - car-sharing
+    profiles: ["mono"]
+
+  # ── Temporal's own metadata store (SEPARATE from the app Postgres) ─────────
+  temporal-postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: temporal
+      POSTGRES_PASSWORD: temporal
+      POSTGRES_DB: temporal
+    volumes:
+      - temporal-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U temporal -d temporal"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    networks:
+      - car-sharing
+    profiles: ["saga"]
+
+  # ── Temporal server (auto-setup creates the `default` namespace) ───────────
+  temporal:
+    image: temporalio/auto-setup:1.25.2
+    depends_on:
+      temporal-postgres:
+        condition: service_healthy
+    environment:
+      - DB=postgres12
+      - DB_PORT=5432
+      - POSTGRES_USER=temporal
+      - POSTGRES_PWD=temporal
+      - POSTGRES_SEEDS=temporal-postgres
+    ports:
+      - "7233:7233"
+    healthcheck:
+      # Wait until the frontend is serving and the default namespace exists.
+      test: ["CMD", "tctl", "--address", "temporal:7233", "namespace", "describe", "default"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+    networks:
+      - car-sharing
+    profiles: ["saga"]
+
+  # ── Temporal Web UI — inspect workflows + their compensations ──────────────
+  temporal-ui:
+    image: temporalio/ui:2.34.0
+    depends_on:
+      temporal:
+        condition: service_healthy
+    environment:
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_CORS_ORIGINS=http://localhost:8088
+    ports:
+      - "8088:8080"
+    networks:
+      - car-sharing
+    profiles: ["saga"]
+
+  # ── FLEET role — the persistent leaf (Drizzle + app Postgres) ──────────────
+  fleet:
+    build: .
+    command: ["node", "src/index.ts"]
+    ports:
+      - "5001:5001"
+    environment:
+      - PORT=5001
+      - SERVICES=fleet.v1.FleetService
+      - DATABASE_URL=postgresql://car_sharing:car_sharing@postgres:5432/car_sharing
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:5001/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    networks:
+      - car-sharing
+    profiles: ["saga"]
+
+  # ── TRIPS role — the edge/gateway; starts TripWorkflow on Temporal ─────────
+  trips:
+    build: .
+    command: ["node", "src/index.ts"]
+    ports:
+      - "5002:5002"
+    environment:
+      - PORT=5002
+      - SERVICES=trips.v1.TripService
+      # buildServer() builds the fleet db client for every role (postgres.js
+      # connects lazily, so this role never opens it — fleet is reached over the
+      # network); DATABASE_URL must still be present.
+      - DATABASE_URL=postgresql://car_sharing:car_sharing@postgres:5432/car_sharing
+      # The pre-check ctx.call to GetVehicle routes here:
+      - FLEET_ADDR=http://fleet:5001
+      # StartTrip starts the durable workflow here:
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_NAMESPACE=default
+      - TEMPORAL_TASK_QUEUE=car-sharing-trips
+    depends_on:
+      fleet:
+        condition: service_healthy
+      temporal:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:5002/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    networks:
+      - car-sharing
+    profiles: ["saga"]
+
+  # ── BILLING role — the in-memory billing leaf ─────────────────────────────
+  billing:
+    build: .
+    command: ["node", "src/index.ts"]
+    ports:
+      - "5003:5003"
+    environment:
+      - PORT=5003
+      - SERVICES=billing.v1.BillingService
+      - DATABASE_URL=postgresql://car_sharing:car_sharing@postgres:5432/car_sharing
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:5003/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    networks:
+      - car-sharing
+    profiles: ["saga"]
+
+  # ── WORKER — hosts TripWorkflow + the activities (node src/worker.ts) ──────
+  #
+  # A separate process type (NOT a SERVICES-selected RPC role): no inbound RPC;
+  # it polls Temporal for workflow/activity tasks and drives the role services
+  # over ConnectRPC. The ONLY process that loads the @temporalio/worker native
+  # addon.
+  worker:
+    build: .
+    command: ["node", "src/worker.ts"]
+    environment:
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TEMPORAL_NAMESPACE=default
+      - TEMPORAL_TASK_QUEUE=car-sharing-trips
+      - FLEET_ADDR=http://fleet:5001
+      - TRIPS_ADDR=http://trips:5002
+      - BILLING_ADDR=http://billing:5003
+    depends_on:
+      temporal:
+        condition: service_healthy
+      fleet:
+        condition: service_healthy
+      trips:
+        condition: service_healthy
+      billing:
+        condition: service_healthy
+    networks:
+      - car-sharing
+    profiles: ["saga"]
+
+networks:
+  car-sharing:
+    driver: bridge
 
 volumes:
   pgdata:
+  temporal-pgdata:

--- a/car-sharing/package.json
+++ b/car-sharing/package.json
@@ -2,7 +2,7 @@
   "name": "@connectum/example-car-sharing",
   "version": "0.1.0",
   "private": true,
-  "description": "Enterprise car-sharing example — gateway JWT + proto authz at the edge, cross-service ctx.call across split microservices, OpenTelemetry, deployed on Kubernetes + Istio. One image, role chosen by SERVICES env.",
+  "description": "Enterprise car-sharing example — gateway JWT + proto authz at the edge, cross-service ctx.call across split microservices, a durable Temporal saga (reserve→record→end→bill→settle with automatic compensation) for the trip lifecycle, OpenTelemetry, deployed on Kubernetes + Istio. One image, role chosen by SERVICES env.",
   "type": "module",
   "imports": {
     "#gen/*": "./gen/*",
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "node src/index.ts",
     "dev": "node --watch src/index.ts",
+    "worker": "node src/worker.ts",
     "typecheck": "tsc --noEmit",
     "buf:generate": "buf generate",
     "buf:lint": "buf lint",
@@ -52,6 +53,10 @@
     "@connectum/interceptors": "^1.0.0",
     "@connectum/otel": "^1.0.0",
     "@connectum/reflection": "^1.0.0",
+    "@temporalio/activity": "^1.18.1",
+    "@temporalio/client": "^1.18.1",
+    "@temporalio/worker": "^1.18.1",
+    "@temporalio/workflow": "^1.18.1",
     "drizzle-orm": "^0.45.0",
     "postgres": "^3.4.0"
   },
@@ -60,6 +65,7 @@
     "@bufbuild/protoc-gen-es": "^2.11.0",
     "@connectum/protoc-gen-catalog": "^1.0.0",
     "@electric-sql/pglite": "^0.5.0",
+    "@temporalio/testing": "^1.18.1",
     "@types/node": "^25.2.0",
     "drizzle-kit": "^0.31.0",
     "typescript": "^5.9.3"

--- a/car-sharing/pnpm-workspace.yaml
+++ b/car-sharing/pnpm-workspace.yaml
@@ -1,5 +1,9 @@
 allowBuilds:
   '@bufbuild/buf': true
+  # @swc/core compiles the Temporal workflow bundle (@temporalio/worker bundles
+  # workflowsPath via swc at worker startup). Allow its build so the prebuilt
+  # native binding is wired up; without this pnpm reports ERR_PNPM_IGNORED_BUILDS.
+  '@swc/core': true
   esbuild: true
   # protobufjs is pulled transitively by @connectum/otel's OTLP/gRPC exporters
   # (@grpc/grpc-js → @grpc/proto-loader → protobufjs). Allow its build so the

--- a/car-sharing/proto/billing/v1/billing.proto
+++ b/car-sharing/proto/billing/v1/billing.proto
@@ -4,17 +4,45 @@ package billing.v1;
 
 import "connectum/auth/v1/options.proto";
 
-// BillingService opens a billing tab for a trip (a leaf service).
+// BillingService keeps a trip's billing tab and charges (a leaf service).
 //
-// Like FleetService, it is INTERNAL: only the trip handler calls it via
-// ctx.call, so it is marked `public: true` (skip authn + authz). The trust
-// boundary is the mesh: Istio mTLS + AuthorizationPolicy restrict who may reach
-// it in production (see istio/).
+// Like FleetService, it is INTERNAL: it is reached only by the trip handler's
+// ctx.call (OpenTab pre-Phase-2) and, in Phase 2, by the Temporal worker's
+// activities (OpenTab / AddCharge / Settle and their compensations VoidTab /
+// RefundCharge). It is marked `service_auth { public: true }`, so the
+// gateway-facing JWT auth and proto authz interceptors skip every RPC: the
+// worker's ConnectRPC clients carry no Authorization header, exactly like the
+// in-process ctx.call did. The trust boundary is the mesh (Istio mTLS +
+// AuthorizationPolicy; see istio/).
+//
+// Persistence stays in-memory in Phase 2 — the DURABLE billing state lives in
+// the Temporal workflow history. The in-memory ledger only needs to record
+// enough (tab state, charges keyed by id) for the compensations to be
+// idempotent: VoidTab on an already-void tab and RefundCharge on an
+// already-refunded charge are no-op successes.
 service BillingService {
   option (connectum.auth.v1.service_auth) = { public: true };
 
-  // OpenTab opens a billing tab for the given trip and returns it.
+  // OpenTab opens a billing tab for the given trip and returns it. Idempotent
+  // by trip_id: re-opening an existing tab returns the same tab.
   rpc OpenTab(OpenTabRequest) returns (OpenTabResponse) {}
+
+  // AddCharge adds a charge line (in minor units, e.g. cents) to a trip's tab
+  // and returns the minted charge id. The saga derives the amount from the trip
+  // duration.
+  rpc AddCharge(AddChargeRequest) returns (AddChargeResponse) {}
+
+  // Settle finalizes (closes) a trip's tab — the terminal happy-path billing
+  // step. FAILED_PRECONDITION if there is no tab for the trip.
+  rpc Settle(SettleRequest) returns (SettleResponse) {}
+
+  // VoidTab voids a trip's tab (saga compensation for OpenTab). Idempotent: a
+  // missing or already-void tab is a no-op success.
+  rpc VoidTab(VoidTabRequest) returns (VoidTabResponse) {}
+
+  // RefundCharge refunds a charge by id (saga compensation for AddCharge).
+  // Idempotent: a missing or already-refunded charge is a no-op success.
+  rpc RefundCharge(RefundChargeRequest) returns (RefundChargeResponse) {}
 }
 
 message OpenTabRequest {
@@ -25,7 +53,48 @@ message OpenTabResponse {
   Tab tab = 1;
 }
 
+message AddChargeRequest {
+  string trip_id = 1;
+  // Charge amount in minor units (e.g. cents). The saga derives it from the
+  // trip duration.
+  int64 amount_cents = 2;
+}
+
+message AddChargeResponse {
+  string charge_id = 1;
+}
+
+message SettleRequest {
+  string trip_id = 1;
+}
+
+message SettleResponse {
+  Tab tab = 1;
+}
+
+message VoidTabRequest {
+  string trip_id = 1;
+}
+
+message VoidTabResponse {
+  // True if a tab existed and is now void (or was already void); false if there
+  // was never a tab for the trip. Either way the call succeeds (idempotent).
+  bool voided = 1;
+}
+
+message RefundChargeRequest {
+  string trip_id = 1;
+  string charge_id = 2;
+}
+
+message RefundChargeResponse {
+  // True if the charge existed and is now refunded (or was already refunded);
+  // false if the charge id is unknown. Either way the call succeeds.
+  bool refunded = 1;
+}
+
 message Tab {
   string id = 1;
+  // True while the tab is open; false once it is settled or voided.
   bool open = 2;
 }

--- a/car-sharing/proto/trips/v1/trips.proto
+++ b/car-sharing/proto/trips/v1/trips.proto
@@ -6,24 +6,54 @@ import "connectum/auth/v1/options.proto";
 
 // TripService is the EDGE service — the only one external clients call.
 //
-// Its handler orchestrates two internal services via ctx.call:
-//   1. fleet.v1.FleetService/GetVehicle — checks availability; an unavailable
-//      vehicle yields FAILED_PRECONDITION.
-//   2. billing.v1.BillingService/OpenTab — opens the billing tab once the trip
-//      starts.
+// Phase 2: StartTrip no longer orchestrates with ctx.call. It now does a
+// SYNCHRONOUS availability pre-check (a ctx.call to FleetService/GetVehicle,
+// preserving today's FAILED_PRECONDITION/NOT_FOUND error contract) and then
+// STARTS a durable Temporal workflow (TripWorkflow) that owns the saga:
+// reserve → record → end → openTab → addCharge → settle, with automatic
+// compensation on failure. StartTrip returns immediately with the trip id, an
+// initial status, and the workflow id. Live status is read via GetTrip, which
+// issues a Temporal Workflow Query.
+//
+// RecordTrip and EndTrip are INTERNAL RPCs the workflow's activities call from
+// the (JWT-less) Temporal worker. They own the in-memory trip ledger.
 //
 // Authorization is declared in proto and enforced by the gateway interceptors:
 //   - service_auth.default_policy = "allow": any AUTHENTICATED caller may invoke
-//     methods that carry no method-level rule. StartTrip therefore requires a
-//     valid JWT (no token -> UNAUTHENTICATED) but no particular role — exactly
-//     the "logged-in user starts a trip" edge contract.
+//     methods that carry no method-level rule (StartTrip, GetTrip) — a valid JWT
+//     is required (no token -> UNAUTHENTICATED) but no particular role.
+//   - method_auth { public: true } on RecordTrip/EndTrip: those two skip both
+//     authn and authz, so the worker's tokenless ConnectRPC client may call
+//     them (mirroring how fleet/billing are service-level public). The real
+//     network trust boundary is the mesh (Istio mTLS + AuthorizationPolicy).
 service TripService {
   option (connectum.auth.v1.service_auth) = { default_policy: "allow" };
 
   // StartTrip starts a trip for (user_id, vehicle_id). Requires a valid JWT.
-  // Returns FAILED_PRECONDITION if the vehicle is unavailable, NOT_FOUND if the
-  // vehicle is unknown (propagated from FleetService).
+  // It pre-checks availability SYNCHRONOUSLY (FAILED_PRECONDITION if the vehicle
+  // is unavailable, NOT_FOUND if unknown — propagated from FleetService) BEFORE
+  // starting the durable workflow, then returns the trip id, initial status, and
+  // the workflow id.
   rpc StartTrip(StartTripRequest) returns (StartTripResponse) {}
+
+  // GetTrip returns a trip's current status. Requires a valid JWT. It reads live
+  // status from the running workflow via a Temporal Workflow Query, falling back
+  // to a terminal status when the workflow has closed.
+  rpc GetTrip(GetTripRequest) returns (GetTripResponse) {}
+
+  // RecordTrip creates the trip ledger row (status STARTED). INTERNAL: called by
+  // the worker's reserve→record activity. Public so the tokenless worker passes
+  // the gateway auth chain.
+  rpc RecordTrip(RecordTripRequest) returns (RecordTripResponse) {
+    option (connectum.auth.v1.method_auth) = { public: true };
+  }
+
+  // EndTrip transitions a trip to a terminal status (ENDED on the happy path,
+  // CANCELLED as the record-trip compensation). INTERNAL: called by the worker's
+  // activities. Public so the tokenless worker passes the gateway auth chain.
+  rpc EndTrip(EndTripRequest) returns (EndTripResponse) {
+    option (connectum.auth.v1.method_auth) = { public: true };
+  }
 }
 
 message StartTripRequest {
@@ -33,10 +63,45 @@ message StartTripRequest {
 
 message StartTripResponse {
   Trip trip = 1;
+  // The durable Temporal workflow id (== the trip id) that orchestrates the
+  // saga. Clients poll status via GetTrip(trip.id). (Additive in Phase 2.)
+  string workflow_id = 2;
+}
+
+message GetTripRequest {
+  string trip_id = 1;
+}
+
+message GetTripResponse {
+  Trip trip = 1;
+}
+
+message RecordTripRequest {
+  string user_id = 1;
+  string vehicle_id = 2;
+  string trip_id = 3;
+}
+
+message RecordTripResponse {
+  Trip trip = 1;
+}
+
+message EndTripRequest {
+  string trip_id = 1;
+  // Target terminal status: "ENDED" (normal finish) or "CANCELLED"
+  // (compensation). See the TripStatus domain in src/temporal/tripStatus.ts.
+  string status = 2;
+}
+
+message EndTripResponse {
+  Trip trip = 1;
 }
 
 message Trip {
   string id = 1;
-  // Trip status: "STARTED" once the vehicle is reserved and the tab is open.
+  // Trip lifecycle status: "STARTED" | "ENDED" | "SETTLED" | "CANCELLED".
+  // Modeled as a string (not a proto enum) so the generated TypeScript stays
+  // erasable (this example's tsconfig sets `erasableSyntaxOnly`). The domain is
+  // pinned in code by the TripStatus `const` object (src/temporal/tripStatus.ts).
   string status = 2;
 }

--- a/car-sharing/src/server.ts
+++ b/car-sharing/src/server.ts
@@ -19,22 +19,25 @@
  * @module server
  */
 
-import { createServer } from "@connectum/core";
-import type { Server } from "@connectum/core";
 import type { Interceptor } from "@connectrpc/connect";
+import type { Server } from "@connectum/core";
+import { createServer } from "@connectum/core";
 import { Healthcheck } from "@connectum/healthcheck";
 import { createDefaultInterceptors, createErrorHandlerInterceptor } from "@connectum/interceptors";
 import { Reflection } from "@connectum/reflection";
-import { serviceCatalog } from "#gen/catalog.gen.ts";
 import { buildAuthInterceptors } from "#auth.ts";
-import { createDb } from "#db/client.ts";
 import type { Db } from "#db/client.ts";
+import { createDb } from "#db/client.ts";
+import { serviceCatalog } from "#gen/catalog.gen.ts";
 import { buildOtelInterceptor } from "#observability.ts";
 import { billingService } from "#services/billingService.ts";
 import { createFleetService } from "#services/fleetService.ts";
-import { tripService } from "#services/tripService.ts";
-import { resolveTopology } from "#topology.ts";
+import type { TripWorkflowClient } from "#services/tripService.ts";
+import { createTripService } from "#services/tripService.ts";
+import { TEMPORAL_TASK_QUEUE } from "#temporal/config.ts";
+import { createWorkflowClient } from "#temporal/workflowClient.ts";
 import type { Topology } from "#topology.ts";
+import { resolveTopology, TYPE_NAMES } from "#topology.ts";
 
 /** Default dev/test JWT secret. Production overrides with `JWT_SECRET`. */
 const DEV_JWT_SECRET = "connectum-test-secret-do-not-use-in-production";
@@ -55,6 +58,18 @@ export interface BuildServerOptions {
      * `ctx.call` to FleetService runs in-process).
      */
     readonly db?: Db;
+    /**
+     * Temporal client override for TripService.
+     *
+     *  - `undefined` (default): when the role hosts TripService, a real LAZY
+     *    `@temporalio/client` `WorkflowClient` is built (no socket until the
+     *    first start/query — so the server starts and the pre-check e2e runs
+     *    without a live Temporal). When the role does NOT host TripService, no
+     *    client is built.
+     *  - a value: injected verbatim (tests pass a stub; pass `null` to force the
+     *    "Temporal not configured" path even when TripService is mounted).
+     */
+    readonly workflowClient?: TripWorkflowClient | null;
 }
 
 /**
@@ -74,6 +89,24 @@ export function buildServer(options: BuildServerOptions = {}): Server {
     // connection is opened only when FleetService actually queries.
     const db = options.db ?? createDb();
     const fleetService = createFleetService(db);
+
+    // Temporal client for the trip saga. Built only when this role hosts
+    // TripService and no override was given. The default client is LAZY (no
+    // socket until the first start/query), so the server starts and the
+    // pre-check e2e runs without a live Temporal server. An explicit `null`
+    // forces the "Temporal not configured" path; an explicit value (a test
+    // stub) is used verbatim.
+    const hostsTrips = topology.localTypeNames.includes(TYPE_NAMES.trips);
+    let workflowClient: TripWorkflowClient | undefined;
+    if (options.workflowClient !== undefined) {
+        workflowClient = options.workflowClient ?? undefined;
+    } else if (hostsTrips) {
+        // The concrete WorkflowClient structurally satisfies the narrow
+        // TripWorkflowClient port (it has start/getHandle/query/describe); the
+        // cast adapts its richer generic overloads to the port the handler uses.
+        workflowClient = createWorkflowClient() as unknown as TripWorkflowClient;
+    }
+    const tripService = createTripService({ workflowClient, taskQueue: TEMPORAL_TASK_QUEUE });
 
     const otelInterceptor = buildOtelInterceptor();
     const interceptors: Interceptor[] = [

--- a/car-sharing/src/services/billingService.ts
+++ b/car-sharing/src/services/billingService.ts
@@ -1,24 +1,73 @@
 /**
- * BillingService — opens a billing tab for a trip (a leaf service).
+ * BillingService — the trip billing ledger (a leaf service, in-memory).
  *
- * In-memory: each OpenTab mints a tab id and records it as open. Like
- * FleetService it is internal-only and marked `public` in its proto, so the
- * gateway auth/authz interceptors skip it on internal `ctx.call`s.
+ * Phase 2: the ledger grows from "open tabs" to the full set the saga's
+ * activities drive — OpenTab / AddCharge / Settle and their compensations
+ * VoidTab / RefundCharge. The DURABLE billing state lives in the Temporal
+ * workflow history; this in-memory store only needs to record enough (tab state
+ * keyed by trip id, charges keyed by charge id) for the compensations to be
+ * IDEMPOTENT, which is the property the saga relies on:
+ *
+ *  - OpenTab is idempotent by trip id (re-open returns the same tab).
+ *  - VoidTab on a missing/already-void tab is a no-op success.
+ *  - RefundCharge on a missing/already-refunded charge is a no-op success.
+ *
+ * Like FleetService it is internal-only and `public` in proto, so the gateway
+ * auth/authz interceptors skip it on the worker's tokenless ConnectRPC calls.
  *
  * @module services/billingService
  */
 
 import { randomUUID } from "node:crypto";
 import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
 import { defineService } from "@connectum/core";
-import { BillingService, OpenTabResponseSchema, TabSchema } from "#gen/billing/v1/billing_pb.ts";
+import {
+    AddChargeResponseSchema,
+    BillingService,
+    OpenTabResponseSchema,
+    RefundChargeResponseSchema,
+    SettleResponseSchema,
+    TabSchema,
+    VoidTabResponseSchema,
+} from "#gen/billing/v1/billing_pb.ts";
 
-/** Demo ledger of open tabs (tab id → trip id). */
-const tabs = new Map<string, string>();
+/** A billing tab's lifecycle in the demo ledger. */
+type TabState = "open" | "settled" | "void";
 
-/** Reset the ledger — used between tests. */
+/** A tab record keyed by trip id. */
+interface TabRecord {
+    id: string;
+    state: TabState;
+}
+
+/** A charge record keyed by charge id. */
+interface ChargeRecord {
+    id: string;
+    tripId: string;
+    amountCents: bigint;
+    refunded: boolean;
+}
+
+/** Demo ledger: tabs keyed by trip id. */
+const tabs = new Map<string, TabRecord>();
+/** Demo ledger: charges keyed by charge id. */
+const charges = new Map<string, ChargeRecord>();
+
+/** Reset the tab ledger — used between tests. */
 export function resetTabs(): void {
     tabs.clear();
+}
+
+/** Reset the charge ledger — used between tests. */
+export function resetCharges(): void {
+    charges.clear();
+}
+
+/** Reset BOTH ledgers — convenience for the saga/activity tests. */
+export function resetBilling(): void {
+    resetTabs();
+    resetCharges();
 }
 
 /** Number of tabs currently recorded (used by tests to assert side effects). */
@@ -26,12 +75,75 @@ export function tabCount(): number {
     return tabs.size;
 }
 
+/** Number of OPEN tabs currently recorded (settled/void excluded). */
+export function openTabCount(): number {
+    let n = 0;
+    for (const tab of tabs.values()) {
+        if (tab.state === "open") n += 1;
+    }
+    return n;
+}
+
+/** Number of charges currently recorded (used by tests to assert side effects). */
+export function chargeCount(): number {
+    return charges.size;
+}
+
+/** Number of NON-refunded charges (used by tests to assert refund compensation). */
+export function activeChargeCount(): number {
+    let n = 0;
+    for (const charge of charges.values()) {
+        if (!charge.refunded) n += 1;
+    }
+    return n;
+}
+
 export const billingService = defineService(BillingService, {
+    // OpenTab is idempotent by trip id: a re-open returns the existing tab.
     openTab: (req) => {
-        const tabId = `tab-${randomUUID()}`;
-        tabs.set(tabId, req.tripId);
-        return create(OpenTabResponseSchema, {
-            tab: create(TabSchema, { id: tabId, open: true }),
-        });
+        const existing = tabs.get(req.tripId);
+        if (existing !== undefined) {
+            return create(OpenTabResponseSchema, { tab: create(TabSchema, { id: existing.id, open: existing.state === "open" }) });
+        }
+        const id = `tab-${randomUUID()}`;
+        tabs.set(req.tripId, { id, state: "open" });
+        return create(OpenTabResponseSchema, { tab: create(TabSchema, { id, open: true }) });
+    },
+
+    // AddCharge appends a charge line; mints and returns the charge id.
+    addCharge: (req) => {
+        const id = `charge-${randomUUID()}`;
+        charges.set(id, { id, tripId: req.tripId, amountCents: req.amountCents, refunded: false });
+        return create(AddChargeResponseSchema, { chargeId: id });
+    },
+
+    // Settle finalizes the tab. FAILED_PRECONDITION if there is no tab.
+    settle: (req) => {
+        const tab = tabs.get(req.tripId);
+        if (tab === undefined) {
+            throw new ConnectError(`No billing tab for trip "${req.tripId}".`, Code.FailedPrecondition);
+        }
+        tab.state = "settled";
+        return create(SettleResponseSchema, { tab: create(TabSchema, { id: tab.id, open: false }) });
+    },
+
+    // VoidTab is the OpenTab compensation. Idempotent: missing/already-void → no-op.
+    voidTab: (req) => {
+        const tab = tabs.get(req.tripId);
+        if (tab === undefined) {
+            return create(VoidTabResponseSchema, { voided: false });
+        }
+        tab.state = "void";
+        return create(VoidTabResponseSchema, { voided: true });
+    },
+
+    // RefundCharge is the AddCharge compensation. Idempotent: missing/already-refunded → no-op.
+    refundCharge: (req) => {
+        const charge = charges.get(req.chargeId);
+        if (charge === undefined) {
+            return create(RefundChargeResponseSchema, { refunded: false });
+        }
+        charge.refunded = true;
+        return create(RefundChargeResponseSchema, { refunded: true });
     },
 });

--- a/car-sharing/src/services/tripService.ts
+++ b/car-sharing/src/services/tripService.ts
@@ -1,20 +1,30 @@
 /**
- * TripService — the edge orchestrator, composing two framework primitives.
+ * TripService — the edge orchestrator, now backed by a durable Temporal saga.
  *
- *  1. `ctx.call("fleet.v1.FleetService/GetVehicle", …)` checks the vehicle
- *     exists and is available. The transport is chosen by the framework:
- *     in-process when FleetService is mounted locally (monolith), or over the
- *     network via the `remoteResolver` when it lives in another pod (split) —
- *     the handler code is identical either way. A `Code.NotFound` from the fleet
- *     (unknown id) propagates straight back to the caller; an unavailable
- *     vehicle is rejected here as `Code.FailedPrecondition`.
- *  2. After reserving the vehicle, `ctx.call("billing.v1.BillingService/OpenTab",
- *     …)` opens the billing tab. Both calls are typed by the generated catalog.
+ * Phase 1 did the whole flow inline with two `ctx.call`s. Phase 2 splits it:
  *
- * Authentication/authorization is NOT handled here — it is enforced by the
- * gateway interceptor chain (JWT auth + proto authz) declared in `server.ts`
- * and `trips.proto`. By the time this handler runs the caller is already
- * authenticated.
+ *  - `StartTrip` keeps a SYNCHRONOUS availability pre-check via
+ *    `ctx.call("fleet.v1.FleetService/GetVehicle", …)` — preserving the exact
+ *    edge error contract (unknown vehicle → `Code.NotFound` propagated from the
+ *    fleet; unavailable vehicle → `Code.FailedPrecondition` raised here). Only
+ *    AFTER the pre-check passes does it START the durable `TripWorkflow`
+ *    (`workflowClient.start(TripWorkflow, { workflowId: tripId })`) and return
+ *    `{ trip: { id, status: STARTED }, workflowId }`. The long-running saga
+ *    (reserve → record → end → openTab → addCharge → settle, with automatic
+ *    compensation) runs in Temporal, not in this handler.
+ *  - `GetTrip` reads LIVE status from the workflow via a Temporal Workflow Query
+ *    (`handle.query(getTripStatusQuery)`), falling back to a terminal status
+ *    derived from `handle.describe()` once the workflow has closed.
+ *  - `RecordTrip` / `EndTrip` are the INTERNAL RPCs the worker's activities call
+ *    (method-level `public` in proto). They own the in-memory trip ledger.
+ *
+ * The Temporal client is INJECTED via the {@link createTripService} factory
+ * (mirroring `createFleetService(db)`), so the server can supply a lazy
+ * `@temporalio/client` `WorkflowClient` in production and tests can inject a
+ * stub. When no client is configured (e.g. a non-trips role, or the
+ * server-only e2e), `StartTrip`'s workflow start and `GetTrip` raise
+ * `Code.Unavailable` — but the pre-check still runs first, so the error-path
+ * e2e needs no live Temporal.
  *
  * @module services/tripService
  */
@@ -22,29 +32,173 @@
 import { randomUUID } from "node:crypto";
 import { create } from "@bufbuild/protobuf";
 import { Code, ConnectError } from "@connectrpc/connect";
+import type { ServiceDefinition } from "@connectum/core";
 import { defineService } from "@connectum/core";
 import { GetVehicleRequestSchema } from "#gen/fleet/v1/fleet_pb.ts";
-import { OpenTabRequestSchema } from "#gen/billing/v1/billing_pb.ts";
-import { StartTripResponseSchema, TripSchema, TripService } from "#gen/trips/v1/trips_pb.ts";
+import { EndTripResponseSchema, GetTripResponseSchema, RecordTripResponseSchema, StartTripResponseSchema, TripSchema, TripService } from "#gen/trips/v1/trips_pb.ts";
+import type { TripStatus as TripStatusT } from "#temporal/tripStatus.ts";
+import { TripStatus } from "#temporal/tripStatus.ts";
+import type { TripWorkflowInput } from "#temporal/workflows.ts";
 
-export const tripService = defineService(TripService, {
-    async startTrip(req, ctx) {
-        // Cross-service call #1 — fleet availability check. An unknown vehicle
-        // throws Code.NotFound inside FleetService; that ConnectError propagates
-        // to the caller unchanged.
-        const vehicle = await ctx.call("fleet.v1.FleetService/GetVehicle", create(GetVehicleRequestSchema, { id: req.vehicleId }));
+// ── Temporal client port ────────────────────────────────────────────────────
+// A minimal structural interface over the `@temporalio/client` `WorkflowClient`
+// the handler actually uses. Typing against a port (not the concrete class)
+// keeps the service import-light and lets tests inject a stub. The real
+// `WorkflowClient` satisfies this shape.
 
-        if (vehicle.vehicle?.available !== true) {
-            throw new ConnectError(`Vehicle "${req.vehicleId}" is not available.`, Code.FailedPrecondition);
-        }
+/** A handle subset: query the live status and describe the (possibly closed) run. */
+export interface TripWorkflowHandle {
+    query<Ret>(queryName: string): Promise<Ret>;
+    describe(): Promise<{ status: { name: string } }>;
+}
 
-        const tripId = `trip-${randomUUID()}`;
+/** The Temporal client subset the trip handler depends on. */
+export interface TripWorkflowClient {
+    start(workflowType: string, options: { taskQueue: string; workflowId: string; args: [TripWorkflowInput] }): Promise<{ workflowId: string }>;
+    getHandle(workflowId: string): TripWorkflowHandle;
+}
 
-        // Cross-service call #2 — open the billing tab for the started trip.
-        await ctx.call("billing.v1.BillingService/OpenTab", create(OpenTabRequestSchema, { tripId }));
+/** Options for {@link createTripService}. */
+export interface TripServiceOptions {
+    /**
+     * Temporal client used to start the saga and read status. Optional: when
+     * absent, the pre-check still runs, but starting the workflow / reading
+     * status raises `Code.Unavailable` (so non-trips roles and the server-only
+     * e2e build and run without Temporal).
+     */
+    readonly workflowClient?: TripWorkflowClient;
+    /** Task queue to start workflows on. */
+    readonly taskQueue: string;
+}
 
-        return create(StartTripResponseSchema, {
-            trip: create(TripSchema, { id: tripId, status: "STARTED" }),
-        });
-    },
-});
+// ── In-memory trip ledger ────────────────────────────────────────────────────
+// The activities (via RecordTrip/EndTrip) own this; StartTrip does NOT write it
+// (the workflow's recordTrip activity does). DURABLE state lives in Temporal.
+
+/** A trip record keyed by trip id. */
+interface TripRecord {
+    id: string;
+    userId: string;
+    vehicleId: string;
+    status: TripStatusT;
+}
+
+/** Demo ledger of trips (trip id → record). */
+const trips = new Map<string, TripRecord>();
+
+/** Reset the trip ledger — used between tests. */
+export function resetTrips(): void {
+    trips.clear();
+}
+
+/** Number of trips currently recorded (used by tests to assert side effects). */
+export function tripCount(): number {
+    return trips.size;
+}
+
+/** Read a recorded trip's status (test/inspection helper). */
+export function tripStatus(tripId: string): TripStatusT | undefined {
+    return trips.get(tripId)?.status;
+}
+
+/** Map a closed-workflow status name to a terminal trip status for GetTrip. */
+function terminalStatusFor(workflowStatusName: string): TripStatusT {
+    // A completed saga settled the trip; anything else (FAILED/CANCELLED/
+    // TERMINATED/TIMED_OUT) means the saga unwound to CANCELLED.
+    return workflowStatusName === "COMPLETED" ? TripStatus.SETTLED : TripStatus.CANCELLED;
+}
+
+/**
+ * Build the TripService definition with an injected Temporal client.
+ *
+ * @param options - {@link TripServiceOptions}.
+ */
+export function createTripService(options: TripServiceOptions): ServiceDefinition {
+    const { workflowClient, taskQueue } = options;
+
+    return defineService(TripService, {
+        async startTrip(req, ctx) {
+            // SYNCHRONOUS availability pre-check — preserves today's edge error
+            // contract. An unknown vehicle throws Code.NotFound inside
+            // FleetService and propagates unchanged; an unavailable one is
+            // rejected here as Code.FailedPrecondition. This runs BEFORE any
+            // Temporal use, so the error-path e2e needs no live Temporal.
+            const vehicle = await ctx.call("fleet.v1.FleetService/GetVehicle", create(GetVehicleRequestSchema, { id: req.vehicleId }));
+
+            if (vehicle.vehicle?.available !== true) {
+                throw new ConnectError(`Vehicle "${req.vehicleId}" is not available.`, Code.FailedPrecondition);
+            }
+
+            if (workflowClient === undefined) {
+                throw new ConnectError("Temporal is not configured — cannot start the trip workflow.", Code.Unavailable);
+            }
+
+            const tripId = `trip-${randomUUID()}`;
+
+            // Start the durable saga (fire-and-forget; the handle returns
+            // immediately). The workflow id IS the trip id, so GetTrip can map
+            // a trip id straight to its workflow.
+            const handle = await workflowClient.start("TripWorkflow", {
+                taskQueue,
+                workflowId: tripId,
+                args: [{ userId: req.userId, vehicleId: req.vehicleId, tripId }],
+            });
+
+            return create(StartTripResponseSchema, {
+                trip: create(TripSchema, { id: tripId, status: TripStatus.STARTED }),
+                workflowId: handle.workflowId,
+            });
+        },
+
+        async getTrip(req) {
+            if (workflowClient === undefined) {
+                throw new ConnectError("Temporal is not configured — cannot read trip status.", Code.Unavailable);
+            }
+
+            const handle = workflowClient.getHandle(req.tripId);
+
+            // Prefer the LIVE status from the running workflow's Query. If the
+            // workflow has closed (queries are rejected on closed runs), fall
+            // back to a terminal status derived from describe().
+            let status: TripStatusT;
+            try {
+                status = await handle.query<TripStatusT>("getTripStatus");
+            } catch {
+                const description = await handle.describe();
+                status = terminalStatusFor(description.status.name);
+            }
+
+            return create(GetTripResponseSchema, {
+                trip: create(TripSchema, { id: req.tripId, status }),
+            });
+        },
+
+        // INTERNAL — called by the worker's reserve→record activity. Creates the
+        // trip ledger row (status STARTED). Idempotent by trip id.
+        recordTrip(req) {
+            const existing = trips.get(req.tripId);
+            if (existing === undefined) {
+                trips.set(req.tripId, { id: req.tripId, userId: req.userId, vehicleId: req.vehicleId, status: TripStatus.STARTED });
+            }
+            const record = trips.get(req.tripId);
+            return create(RecordTripResponseSchema, { trip: create(TripSchema, { id: req.tripId, status: record?.status ?? TripStatus.STARTED }) });
+        },
+
+        // INTERNAL — called by the worker's end / cancel activities. Transitions
+        // the trip to a terminal status (ENDED on finish, CANCELLED as the
+        // record-trip compensation). Idempotent: re-applying the same terminal
+        // status is a no-op; CANCELLED always wins over a prior ENDED (the saga
+        // rolled back).
+        endTrip(req) {
+            const record = trips.get(req.tripId);
+            const target: TripStatusT = req.status === TripStatus.CANCELLED ? TripStatus.CANCELLED : TripStatus.ENDED;
+            if (record !== undefined) {
+                // CANCELLED is terminal-dominant; never downgrade it back to ENDED.
+                if (record.status !== TripStatus.CANCELLED) {
+                    record.status = target;
+                }
+            }
+            return create(EndTripResponseSchema, { trip: create(TripSchema, { id: req.tripId, status: record?.status ?? target }) });
+        },
+    });
+}

--- a/car-sharing/src/temporal/activities.ts
+++ b/car-sharing/src/temporal/activities.ts
@@ -1,0 +1,142 @@
+/**
+ * Temporal activities — the saga's side effects, each a ConnectRPC call.
+ *
+ * Activities run in the worker's Node process (NOT the deterministic workflow
+ * sandbox), so they may freely create ConnectRPC clients and do I/O. Each
+ * activity is one RPC against a role service over the network (`*_ADDR`). The
+ * workflow (`workflows.ts`) only `proxyActivities` these and never touches a
+ * client itself.
+ *
+ * Activities are grouped:
+ *  - forward steps: reserveVehicle, recordTrip, endTrip, openTab, addCharge,
+ *    settle.
+ *  - compensations: releaseVehicle, markTripCancelled, voidTab, refundCharge —
+ *    all IDEMPOTENT (the services no-op on already-done state), since a
+ *    compensation may run after a forward step partially applied.
+ *
+ * Business failures of the very first step (vehicle unavailable / unknown) are
+ * rethrown as a NON-RETRYABLE `ApplicationFailure` so Temporal fails the
+ * workflow fast (no pointless retries, no compensation — nothing was reserved).
+ * Transient/infra failures of every other step stay retryable, which is the
+ * whole point of the durable saga, so they are NOT marked non-retryable here.
+ *
+ * @module temporal/activities
+ */
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { ApplicationFailure } from "@temporalio/activity";
+import { AddChargeRequestSchema, OpenTabRequestSchema, RefundChargeRequestSchema, SettleRequestSchema, VoidTabRequestSchema } from "#gen/billing/v1/billing_pb.ts";
+import { ReleaseVehicleRequestSchema, ReserveVehicleRequestSchema } from "#gen/fleet/v1/fleet_pb.ts";
+import { EndTripRequestSchema, RecordTripRequestSchema } from "#gen/trips/v1/trips_pb.ts";
+import type { ServiceClients } from "#temporal/clients.ts";
+import { createServiceClients } from "#temporal/clients.ts";
+import { TripStatus } from "#temporal/tripStatus.ts";
+
+/**
+ * Error type for a non-retryable, business availability failure of step 1.
+ * The workflow lists this string in `nonRetryableErrorTypes` (by the SAME
+ * literal value) and surfaces it as a terminal workflow failure (preserving
+ * today's FAILED_PRECONDITION/NOT_FOUND meaning).
+ *
+ * NOT exported: only used inside this module, and keeping the activities
+ * namespace function-only (so `import * as activities` passed to `Worker.create`
+ * carries no non-function entry).
+ */
+const VEHICLE_UNAVAILABLE = "VehicleUnavailable" as const;
+
+/** Charge rate in minor units (cents) per second of trip — demo pricing. */
+const CENTS_PER_SECOND = 5;
+
+/** Lazily-built shared clients (one transport set per worker process). */
+let sharedClients: ServiceClients | undefined;
+
+/** Get (or build once) the worker's service clients. */
+function clients(): ServiceClients {
+    if (sharedClients === undefined) {
+        sharedClients = createServiceClients();
+    }
+    return sharedClients;
+}
+
+/** Compute a demo charge (in cents) from a trip's duration in milliseconds. */
+function chargeCents(durationMs: number): bigint {
+    const seconds = Math.max(1, Math.ceil(durationMs / 1000));
+    return BigInt(seconds * CENTS_PER_SECOND);
+}
+
+// ── Forward steps ─────────────────────────────────────────────────────────
+
+/**
+ * Step 1 — reserve the vehicle. A business failure (unavailable / unknown) is
+ * rethrown as a NON-RETRYABLE `ApplicationFailure(VEHICLE_UNAVAILABLE)` so the
+ * workflow fails fast with no compensation; any other (infra) error stays
+ * retryable.
+ *
+ * @param input - `{ vehicleId }`.
+ */
+export async function reserveVehicle(input: { vehicleId: string }): Promise<void> {
+    try {
+        await clients().fleet.reserveVehicle(create(ReserveVehicleRequestSchema, { id: input.vehicleId }));
+    } catch (err) {
+        if (err instanceof ConnectError && (err.code === Code.FailedPrecondition || err.code === Code.NotFound)) {
+            throw ApplicationFailure.create({
+                message: err.message,
+                type: VEHICLE_UNAVAILABLE,
+                nonRetryable: true,
+            });
+        }
+        throw err;
+    }
+}
+
+/** Compensation for step 1 — release the vehicle. Idempotent. */
+export async function releaseVehicle(input: { vehicleId: string }): Promise<void> {
+    await clients().fleet.releaseVehicle(create(ReleaseVehicleRequestSchema, { id: input.vehicleId }));
+}
+
+/** Step 2 — create the trip ledger row (status STARTED). */
+export async function recordTrip(input: { userId: string; vehicleId: string; tripId: string }): Promise<void> {
+    await clients().trips.recordTrip(create(RecordTripRequestSchema, { userId: input.userId, vehicleId: input.vehicleId, tripId: input.tripId }));
+}
+
+/** Compensation for step 2 — mark the trip CANCELLED. Idempotent. */
+export async function markTripCancelled(input: { tripId: string }): Promise<void> {
+    await clients().trips.endTrip(create(EndTripRequestSchema, { tripId: input.tripId, status: TripStatus.CANCELLED }));
+}
+
+/** Step 4 — close the trip (status ENDED). No own compensation (step 2's covers rollback). */
+export async function endTrip(input: { tripId: string }): Promise<void> {
+    await clients().trips.endTrip(create(EndTripRequestSchema, { tripId: input.tripId, status: TripStatus.ENDED }));
+}
+
+/** Step 5 — open the billing tab. */
+export async function openTab(input: { tripId: string }): Promise<void> {
+    await clients().billing.openTab(create(OpenTabRequestSchema, { tripId: input.tripId }));
+}
+
+/** Compensation for step 5 — void the tab. Idempotent. */
+export async function voidTab(input: { tripId: string }): Promise<void> {
+    await clients().billing.voidTab(create(VoidTabRequestSchema, { tripId: input.tripId }));
+}
+
+/**
+ * Step 6 — add a charge derived from the trip duration; returns the charge id
+ * (the workflow remembers it so its compensation can refund precisely).
+ *
+ * @param input - `{ tripId, durationMs }`.
+ */
+export async function addCharge(input: { tripId: string; durationMs: number }): Promise<string> {
+    const res = await clients().billing.addCharge(create(AddChargeRequestSchema, { tripId: input.tripId, amountCents: chargeCents(input.durationMs) }));
+    return res.chargeId;
+}
+
+/** Compensation for step 6 — refund the charge by id. Idempotent. */
+export async function refundCharge(input: { tripId: string; chargeId: string }): Promise<void> {
+    await clients().billing.refundCharge(create(RefundChargeRequestSchema, { tripId: input.tripId, chargeId: input.chargeId }));
+}
+
+/** Step 7 — settle (finalize) the tab. The terminal happy-path step. */
+export async function settle(input: { tripId: string }): Promise<void> {
+    await clients().billing.settle(create(SettleRequestSchema, { tripId: input.tripId }));
+}

--- a/car-sharing/src/temporal/clients.ts
+++ b/car-sharing/src/temporal/clients.ts
@@ -1,0 +1,55 @@
+/**
+ * ConnectRPC client factory for the Temporal activities.
+ *
+ * The worker is a separate process with NO Connectum `Server`, so the in-process
+ * `ctx.call` / `server.client()` facilities are unavailable there. Activities
+ * therefore reach the role services as a plain network client — exactly the
+ * example's cross-pod story (`*_ADDR` env), just initiated from the worker
+ * instead of a request handler.
+ *
+ * The clients carry no Authorization header. That is fine: fleet/billing are
+ * service-level `public`, and the trips RPCs the activities call (RecordTrip /
+ * EndTrip) are method-level `public` (see trips.proto) — both skip the gateway
+ * auth chain. The real trust boundary is the mesh.
+ *
+ * @module temporal/clients
+ */
+
+import type { Client } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { BillingService } from "#gen/billing/v1/billing_pb.ts";
+import { FleetService } from "#gen/fleet/v1/fleet_pb.ts";
+import { TripService } from "#gen/trips/v1/trips_pb.ts";
+
+/** Default endpoints for a local `docker compose up` (one role per service). */
+const DEFAULT_FLEET_ADDR = "http://localhost:5001";
+const DEFAULT_TRIPS_ADDR = "http://localhost:5002";
+const DEFAULT_BILLING_ADDR = "http://localhost:5003";
+
+/** The typed clients the activities use to drive the saga's RPCs. */
+export interface ServiceClients {
+    readonly fleet: Client<typeof FleetService>;
+    readonly trips: Client<typeof TripService>;
+    readonly billing: Client<typeof BillingService>;
+}
+
+/**
+ * Build the fleet/trips/billing clients from the `*_ADDR` env convention.
+ *
+ * `createGrpcTransport({ baseUrl })` requires a full URL (`http://host:port`),
+ * the same shape `TRIPS_ADDR`/`FLEET_ADDR`/`BILLING_ADDR` carry in k8s/compose.
+ *
+ * @param env - Process env to read endpoints from (defaults to `process.env`).
+ */
+export function createServiceClients(env: NodeJS.ProcessEnv = process.env): ServiceClients {
+    const fleetAddr = env.FLEET_ADDR ?? DEFAULT_FLEET_ADDR;
+    const tripsAddr = env.TRIPS_ADDR ?? DEFAULT_TRIPS_ADDR;
+    const billingAddr = env.BILLING_ADDR ?? DEFAULT_BILLING_ADDR;
+
+    return {
+        fleet: createClient(FleetService, createGrpcTransport({ baseUrl: fleetAddr })),
+        trips: createClient(TripService, createGrpcTransport({ baseUrl: tripsAddr })),
+        billing: createClient(BillingService, createGrpcTransport({ baseUrl: billingAddr })),
+    };
+}

--- a/car-sharing/src/temporal/config.ts
+++ b/car-sharing/src/temporal/config.ts
@@ -1,0 +1,23 @@
+/**
+ * Temporal configuration — the single source of truth for the durable layer.
+ *
+ * Read once from env so the gateway (which builds a `@temporalio/client`), the
+ * worker (`@temporalio/worker`), and the dockerless tests all agree on the
+ * connection target, namespace, and task queue. The defaults make a local
+ * `docker compose up` (temporalio/auto-setup on `:7233`, namespace `default`)
+ * work with no extra env.
+ *
+ * @module temporal/config
+ */
+
+/** Temporal frontend gRPC address (host:port). Compose sets `temporal:7233`. */
+export const TEMPORAL_ADDRESS = process.env.TEMPORAL_ADDRESS ?? "localhost:7233";
+
+/** Temporal namespace. `temporalio/auto-setup` creates `default`. */
+export const TEMPORAL_NAMESPACE = process.env.TEMPORAL_NAMESPACE ?? "default";
+
+/**
+ * Task queue the worker polls and the gateway targets when starting workflows.
+ * Both sides MUST agree, or started workflows are never picked up.
+ */
+export const TEMPORAL_TASK_QUEUE = process.env.TEMPORAL_TASK_QUEUE ?? "car-sharing-trips";

--- a/car-sharing/src/temporal/tripStatus.ts
+++ b/car-sharing/src/temporal/tripStatus.ts
@@ -1,0 +1,35 @@
+/**
+ * Trip lifecycle status domain — a side-effect-free `const` object.
+ *
+ * This module is imported by BOTH the Temporal workflow (`workflows.ts`, which
+ * runs in the deterministic, bundled sandbox) and the Node-side services /
+ * activities. It therefore MUST stay import-clean: no Node built-ins, no
+ * Connectum/generated runtime, no Drizzle — only this literal map. Importing a
+ * module with side effects (e.g. `db/schema.ts`, which pulls in drizzle) into
+ * the workflow bundle would break determinism, so the trip-status domain lives
+ * here on its own rather than next to {@link VehicleStatus}.
+ *
+ * The status is a plain string on the wire (no proto enum — the example's
+ * `erasableSyntaxOnly` tsconfig rejects the native `enum` protoc-gen-es emits),
+ * with the domain pinned by this `const` object (ADR-001: no `enum`).
+ *
+ * @module temporal/tripStatus
+ */
+
+/**
+ * Trip lifecycle states.
+ *
+ *  - `STARTED`   — vehicle reserved, trip row created, drive in progress.
+ *  - `ENDED`     — drive finished, duration known, billing not yet settled.
+ *  - `SETTLED`   — billing tab finalized; the terminal happy-path state.
+ *  - `CANCELLED` — the saga rolled back (a compensation closed the trip).
+ */
+export const TripStatus = {
+    STARTED: "STARTED",
+    ENDED: "ENDED",
+    SETTLED: "SETTLED",
+    CANCELLED: "CANCELLED",
+} as const;
+
+/** One of the {@link TripStatus} string values. */
+export type TripStatus = (typeof TripStatus)[keyof typeof TripStatus];

--- a/car-sharing/src/temporal/workflowClient.ts
+++ b/car-sharing/src/temporal/workflowClient.ts
@@ -1,0 +1,31 @@
+/**
+ * Lazy Temporal client factory for the gateway (TripService) role.
+ *
+ * Builds a `@temporalio/client` `WorkflowClient` over a LAZY connection
+ * (`Connection.lazy` opens no socket until the first call). That laziness is
+ * what lets the server START — and the pre-check e2e run — WITHOUT a live
+ * Temporal server: only an actual `StartTrip` that reaches `workflowClient.start`
+ * (or a `GetTrip` query) touches Temporal.
+ *
+ * `@temporalio/client` is pure JS (no core-bridge native addon), so importing it
+ * here keeps every RPC role on its no-build native-TS run model — only
+ * `src/worker.ts` pulls the native worker.
+ *
+ * @module temporal/workflowClient
+ */
+
+import { Client, Connection } from "@temporalio/client";
+import { TEMPORAL_ADDRESS, TEMPORAL_NAMESPACE } from "#temporal/config.ts";
+
+/** The `WorkflowClient` shape (a subset is consumed by `createTripService`). */
+export type WorkflowClient = Client["workflow"];
+
+/**
+ * Create a `WorkflowClient` over a lazy connection. No socket opens until the
+ * first workflow start/query, so this is safe to construct in any topology.
+ */
+export function createWorkflowClient(): WorkflowClient {
+    const connection = Connection.lazy({ address: TEMPORAL_ADDRESS });
+    const client = new Client({ connection, namespace: TEMPORAL_NAMESPACE });
+    return client.workflow;
+}

--- a/car-sharing/src/temporal/workflows.ts
+++ b/car-sharing/src/temporal/workflows.ts
@@ -1,0 +1,135 @@
+/**
+ * TripWorkflow — the durable trip saga (Temporal workflow code).
+ *
+ * This file is the worker's `workflowsPath` target: it is bundled (webpack +
+ * swc) and runs in Temporal's DETERMINISTIC sandbox. It therefore imports ONLY
+ * `@temporalio/workflow`, the activity *types*, and the side-effect-free
+ * `tripStatus.ts` — never Node built-ins, Connectum, or the generated runtime
+ * (that would break determinism). All I/O is in the activities; the workflow
+ * only orchestrates.
+ *
+ * Saga (compensation-stack pattern, samples-repo style): run the forward steps
+ * in order; after each side-effecting step `unshift` its compensation onto a
+ * stack; on ANY failure, run the compensations in LIFO order (each wrapped in
+ * its own try/catch so the unwind never throws), then rethrow the original
+ * error. The result:
+ *   - settle fails  → refundCharge → voidTab → markTripCancelled → releaseVehicle
+ *   - endTrip fails → markTripCancelled → releaseVehicle
+ *   - reserve fails → (non-retryable) fail fast, NOTHING to compensate.
+ *
+ * endTrip (step 4) and settle (step 7) push NO compensation: rollback after
+ * step 4+ reuses step 2's markTripCancelled, and settle is terminal.
+ *
+ * Live status is exposed via `getTripStatusQuery` so the gateway's GetTrip can
+ * read it with `handle.query(getTripStatusQuery)`.
+ *
+ * @module temporal/workflows
+ */
+
+import { ApplicationFailure, defineQuery, log, proxyActivities, setHandler, sleep } from "@temporalio/workflow";
+import type * as activities from "#temporal/activities.ts";
+import type { TripStatus as TripStatusT } from "#temporal/tripStatus.ts";
+import { TripStatus } from "#temporal/tripStatus.ts";
+
+/** Input to {@link TripWorkflow}. */
+export interface TripWorkflowInput {
+    readonly userId: string;
+    readonly vehicleId: string;
+    readonly tripId: string;
+}
+
+/**
+ * Query for the trip's live status, read from outside via
+ * `handle.query(getTripStatusQuery)`. Returns the current {@link TripStatus}.
+ */
+export const getTripStatusQuery = defineQuery<TripStatusT>("getTripStatus");
+
+/** A single compensation: a label (for assertions/logs) and its undo action. */
+interface Compensation {
+    readonly name: string;
+    readonly run: () => Promise<void>;
+}
+
+/**
+ * Activity proxies. `reserveVehicle`'s business failure is non-retryable (the
+ * activity rethrows `ApplicationFailure(VEHICLE_UNAVAILABLE)`); every other
+ * step keeps Temporal's default retry policy, which is the durability the saga
+ * demonstrates.
+ */
+const acts = proxyActivities<typeof activities>({
+    startToCloseTimeout: "30 seconds",
+    retry: {
+        initialInterval: "1 second",
+        maximumAttempts: 5,
+        // Business availability failures must not be retried.
+        nonRetryableErrorTypes: ["VehicleUnavailable"],
+    },
+});
+
+/** Simulated drive duration (time-skipped instantly in tests). */
+const DRIVE_DURATION_MS = 60_000;
+
+/**
+ * Run the trip saga for `(userId, vehicleId, tripId)`.
+ *
+ * @param input - {@link TripWorkflowInput}.
+ * @returns the terminal trip status (`SETTLED` on success).
+ */
+export async function TripWorkflow(input: TripWorkflowInput): Promise<TripStatusT> {
+    const { userId, vehicleId, tripId } = input;
+
+    let status: TripStatusT = TripStatus.STARTED;
+    setHandler(getTripStatusQuery, () => status);
+
+    // LIFO compensation stack: unshift after each side-effecting forward step.
+    const compensations: Compensation[] = [];
+
+    try {
+        // Step 1 — reserve the vehicle (business failure here is non-retryable
+        // and fails the workflow fast; nothing pushed, nothing to undo).
+        await acts.reserveVehicle({ vehicleId });
+        compensations.unshift({ name: "releaseVehicle", run: () => acts.releaseVehicle({ vehicleId }) });
+
+        // Step 2 — record the trip (STARTED).
+        await acts.recordTrip({ userId, vehicleId, tripId });
+        compensations.unshift({ name: "markTripCancelled", run: () => acts.markTripCancelled({ tripId }) });
+        status = TripStatus.STARTED;
+
+        // Step 3 — the drive. A timer; time-skipped instantly under test.
+        await sleep(DRIVE_DURATION_MS);
+
+        // Step 4 — end the trip (ENDED). No own compensation: a later failure
+        // rolls the trip back to CANCELLED via step 2's compensation.
+        await acts.endTrip({ tripId });
+        status = TripStatus.ENDED;
+
+        // Step 5 — open the billing tab.
+        await acts.openTab({ tripId });
+        compensations.unshift({ name: "voidTab", run: () => acts.voidTab({ tripId }) });
+
+        // Step 6 — add the charge derived from the drive duration.
+        const chargeId = await acts.addCharge({ tripId, durationMs: DRIVE_DURATION_MS });
+        compensations.unshift({ name: "refundCharge", run: () => acts.refundCharge({ tripId, chargeId }) });
+
+        // Step 7 — settle the tab. Terminal; no compensation.
+        await acts.settle({ tripId });
+        status = TripStatus.SETTLED;
+
+        return status;
+    } catch (err) {
+        // Unwind in LIFO order; each compensation is isolated so the unwind
+        // never throws. Temporal already retried each forward+comp activity.
+        log.warn("TripWorkflow failed; compensating", { tripId, error: String(err) });
+        for (const comp of compensations) {
+            try {
+                await comp.run();
+            } catch (compErr) {
+                log.error("compensation failed (continuing unwind)", { tripId, compensation: comp.name, error: String(compErr) });
+            }
+        }
+        status = TripStatus.CANCELLED;
+        // Preserve the original failure so it surfaces in temporal-ui / GetTrip.
+        if (err instanceof ApplicationFailure) throw err;
+        throw ApplicationFailure.create({ message: String(err), type: "TripWorkflowFailed" });
+    }
+}

--- a/car-sharing/src/worker.ts
+++ b/car-sharing/src/worker.ts
@@ -1,0 +1,46 @@
+/**
+ * Temporal worker — the durable saga's host process.
+ *
+ * This is a NEW process type alongside the RPC roles. It is the ONLY entry that
+ * imports `@temporalio/worker` (the Rust core-bridge native addon + the
+ * webpack/swc workflow bundler), so the existing `node src/index.ts` roles keep
+ * their no-build, native-TS run model untouched. The worker runs its own
+ * process (`node src/worker.ts`), not a `SERVICES`-selected role — it has no
+ * inbound RPC; it polls Temporal for workflow/activity tasks.
+ *
+ * `Worker.create({ workflowsPath })` bundles `temporal/workflows.ts` on the fly
+ * (swc) at startup — no separate build step. Under ESM, `workflowsPath` is
+ * resolved with `fileURLToPath(new URL(...))`. The activities run here in full
+ * Node and drive the role services over ConnectRPC (`temporal/clients.ts`).
+ *
+ * @module worker
+ */
+
+import { fileURLToPath } from "node:url";
+import { NativeConnection, Worker } from "@temporalio/worker";
+import * as activities from "#temporal/activities.ts";
+import { TEMPORAL_ADDRESS, TEMPORAL_NAMESPACE, TEMPORAL_TASK_QUEUE } from "#temporal/config.ts";
+
+async function main(): Promise<void> {
+    const connection = await NativeConnection.connect({ address: TEMPORAL_ADDRESS });
+    try {
+        const worker = await Worker.create({
+            connection,
+            namespace: TEMPORAL_NAMESPACE,
+            taskQueue: TEMPORAL_TASK_QUEUE,
+            // Bundled (swc) at startup — no build step; ESM-safe path resolution.
+            workflowsPath: fileURLToPath(new URL("./temporal/workflows.ts", import.meta.url)),
+            activities,
+        });
+
+        console.log(`car-sharing temporal worker ready — taskQueue=${TEMPORAL_TASK_QUEUE} namespace=${TEMPORAL_NAMESPACE} temporal=${TEMPORAL_ADDRESS}`);
+        await worker.run();
+    } finally {
+        await connection.close();
+    }
+}
+
+main().catch((err: unknown) => {
+    console.error("car-sharing temporal worker error:", err);
+    process.exitCode = 1;
+});

--- a/car-sharing/tests/activity/activities.test.ts
+++ b/car-sharing/tests/activity/activities.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Activity ↔ RPC wiring + compensation idempotency tests — DOCKERLESS.
+ *
+ * Runs the REAL activity bodies (via `MockActivityEnvironment`) against a REAL
+ * in-process Connectum monolith (`buildServer({ port: 0 })`) — the same server
+ * the e2e uses, with a PGlite-backed FleetService and the in-memory
+ * BillingService/TripService. No Temporal cluster, no Docker. This proves:
+ *
+ *  - each forward activity calls its RPC and mutates the real service state
+ *    (`tabCount`/`chargeCount`/`tripStatus`), including the happy-path billing
+ *    side effects (openTab → addCharge → settle) that MOVED off the e2e from
+ *    Phase 1's synchronous StartTrip;
+ *  - the compensating activities are IDEMPOTENT — running release/void/refund
+ *    twice (or on already-undone state) is a no-op success.
+ *
+ * The activities read endpoints from `*_ADDR`; this test points all three at the
+ * one in-process monolith before any activity builds its (lazily cached) client.
+ *
+ * @module tests/activity/activities
+ */
+
+import assert from "node:assert/strict";
+import { after, before, beforeEach, describe, it } from "node:test";
+import type { Server } from "@connectum/core";
+import { ApplicationFailure } from "@temporalio/activity";
+import { MockActivityEnvironment } from "@temporalio/testing";
+import { buildServer } from "#server.ts";
+import { activeChargeCount, chargeCount, openTabCount, resetBilling, tabCount } from "#services/billingService.ts";
+import { resetTrips, tripStatus } from "#services/tripService.ts";
+import * as activities from "#temporal/activities.ts";
+import { TripStatus } from "#temporal/tripStatus.ts";
+import { resolveTopology } from "#topology.ts";
+import { makeTestDb, reseed } from "../helpers/db.ts";
+
+const env = new MockActivityEnvironment();
+
+/** Run a real activity body inside a mocked Temporal Activity Context. */
+function run<A extends unknown[], R>(fn: (...args: A) => Promise<R>, ...args: A): Promise<R> {
+    return env.run(fn, ...args);
+}
+
+describe("Activities: real RPC wiring + compensation idempotency (in-process monolith, PGlite)", () => {
+    let server: Server;
+    let db: Awaited<ReturnType<typeof makeTestDb>>;
+
+    before(async () => {
+        const topology = resolveTopology("*");
+        db = await makeTestDb();
+        // Mount trips without a Temporal client (`null`): only RecordTrip/EndTrip
+        // are exercised here, which never touch the workflow client.
+        server = buildServer({ port: 0, topology, db, workflowClient: null });
+        await server.start();
+        const port = server.address?.port ?? 0;
+        const addr = `http://localhost:${port}`;
+        // Point every activity client at the one in-process monolith. Set BEFORE
+        // the first activity call, since activities cache their clients lazily.
+        process.env.FLEET_ADDR = addr;
+        process.env.TRIPS_ADDR = addr;
+        process.env.BILLING_ADDR = addr;
+    });
+
+    beforeEach(async () => {
+        await reseed(db);
+        resetBilling();
+        resetTrips();
+    });
+
+    after(async () => {
+        if (server.state === "running") await server.stop();
+    });
+
+    it("forward billing steps open a tab, add a charge, and settle (the moved happy-path side effects)", async () => {
+        const tripId = "trip-act-1";
+        assert.equal(tabCount(), 0);
+        assert.equal(chargeCount(), 0);
+
+        await run(activities.openTab, { tripId });
+        assert.equal(tabCount(), 1);
+        assert.equal(openTabCount(), 1);
+
+        const chargeId = await run(activities.addCharge, { tripId, durationMs: 60_000 });
+        assert.ok(chargeId.startsWith("charge-"));
+        assert.equal(chargeCount(), 1);
+        assert.equal(activeChargeCount(), 1);
+
+        await run(activities.settle, { tripId });
+        // Settle closes the tab (no longer open) but does not remove it.
+        assert.equal(tabCount(), 1);
+        assert.equal(openTabCount(), 0);
+    });
+
+    it("reserveVehicle drives FleetService and recordTrip/endTrip drive the trip ledger", async () => {
+        const tripId = "trip-act-2";
+        await run(activities.reserveVehicle, { vehicleId: "v-001" });
+
+        await run(activities.recordTrip, { userId: "user-42", vehicleId: "v-001", tripId });
+        assert.equal(tripStatus(tripId), TripStatus.STARTED);
+
+        await run(activities.endTrip, { tripId });
+        assert.equal(tripStatus(tripId), TripStatus.ENDED);
+    });
+
+    it("reserveVehicle on an UNAVAILABLE vehicle throws a NON-RETRYABLE VehicleUnavailable ApplicationFailure", async () => {
+        // v-003 is maintenance in the seed → ReserveVehicle is FAILED_PRECONDITION,
+        // which the activity rethrows as a non-retryable ApplicationFailure whose
+        // `type` is exactly the value the workflow lists in nonRetryableErrorTypes.
+        await assert.rejects(
+            run(activities.reserveVehicle, { vehicleId: "v-003" }),
+            (err: unknown) =>
+                err instanceof ApplicationFailure && err.type === "VehicleUnavailable" && err.nonRetryable === true && /not available/i.test(err.message),
+        );
+    });
+
+    it("reserveVehicle on an UNKNOWN vehicle also throws a NON-RETRYABLE VehicleUnavailable ApplicationFailure", async () => {
+        await assert.rejects(
+            run(activities.reserveVehicle, { vehicleId: "ghost" }),
+            (err: unknown) => err instanceof ApplicationFailure && err.type === "VehicleUnavailable" && err.nonRetryable === true,
+        );
+    });
+
+    it("releaseVehicle is idempotent: releasing an already-available vehicle is a no-op success", async () => {
+        await run(activities.reserveVehicle, { vehicleId: "v-001" });
+        await run(activities.releaseVehicle, { vehicleId: "v-001" });
+        // Second release on an already-available vehicle must not throw.
+        await run(activities.releaseVehicle, { vehicleId: "v-001" });
+    });
+
+    it("voidTab is idempotent: voiding twice (and a missing tab) is a no-op success", async () => {
+        const tripId = "trip-act-void";
+        await run(activities.openTab, { tripId });
+        await run(activities.voidTab, { tripId });
+        assert.equal(openTabCount(), 0);
+        // Void again — already void.
+        await run(activities.voidTab, { tripId });
+        // Void a trip that never had a tab — still a no-op success.
+        await run(activities.voidTab, { tripId: "trip-never" });
+    });
+
+    it("refundCharge is idempotent: refunding twice (and an unknown charge) is a no-op success", async () => {
+        const tripId = "trip-act-refund";
+        const chargeId = await run(activities.addCharge, { tripId, durationMs: 30_000 });
+        assert.equal(activeChargeCount(), 1);
+
+        await run(activities.refundCharge, { tripId, chargeId });
+        assert.equal(activeChargeCount(), 0);
+        // Refund again — already refunded.
+        await run(activities.refundCharge, { tripId, chargeId });
+        // Refund an unknown charge — still a no-op success.
+        await run(activities.refundCharge, { tripId, chargeId: "charge-ghost" });
+    });
+
+    it("markTripCancelled overrides a recorded trip to CANCELLED and never downgrades", async () => {
+        const tripId = "trip-act-cancel";
+        await run(activities.recordTrip, { userId: "user-42", vehicleId: "v-002", tripId });
+        await run(activities.markTripCancelled, { tripId });
+        assert.equal(tripStatus(tripId), TripStatus.CANCELLED);
+        // A late endTrip(ENDED) must not resurrect the trip.
+        await run(activities.endTrip, { tripId });
+        assert.equal(tripStatus(tripId), TripStatus.CANCELLED);
+    });
+});

--- a/car-sharing/tests/e2e/e2e.test.ts
+++ b/car-sharing/tests/e2e/e2e.test.ts
@@ -1,71 +1,114 @@
 /**
- * E2E tests — MONOLITH mode, in-process, no cluster.
+ * E2E tests — MONOLITH mode, in-process, no cluster, no live Temporal.
  *
  * The whole car-sharing app runs in ONE process; every service is mounted
- * locally, so the headline flows are verified end to end without Kubernetes,
- * Istio, or a Collector:
+ * locally. Phase 2 changed StartTrip from an inline `ctx.call` chain to a
+ * synchronous availability PRE-CHECK followed by STARTING a durable Temporal
+ * workflow. That reshapes what the server-only e2e can assert:
  *
- *  - StartTrip validates the vehicle via `ctx.call` to FleetService (in-process),
- *    then opens a billing tab via `ctx.call` to BillingService — proving the
- *    cross-service orchestration and that internal calls to the `public`
- *    fleet/billing services pass through the SAME gateway interceptor chain
- *    WITHOUT an Authorization header.
- *  - An unavailable vehicle is rejected as `Code.FailedPrecondition` (the trip
- *    handler's own guard); an unknown vehicle surfaces `Code.NotFound` straight
- *    out of `ctx.call` (propagated from FleetService).
- *  - The gateway auth: a StartTrip with NO token is rejected as
- *    `Code.Unauthenticated` by the JWT interceptor, while a request with a valid
- *    Bearer token succeeds. This is asserted over the HTTP/2 gRPC transport
- *    (the server runs `allowHTTP1: false`), with the JWT minted by the shared
- *    test secret.
+ *  - The PRE-CHECK error paths still run WITHOUT a live Temporal, because they
+ *    fail BEFORE the workflow is started: an unavailable vehicle →
+ *    `Code.FailedPrecondition` (the trip handler's guard), an unknown vehicle →
+ *    `Code.NotFound` (propagated from FleetService's `ctx.call`). A STUB
+ *    Temporal client is injected so the success path can be asserted too — it
+ *    records the `start` call instead of contacting a real server, proving the
+ *    pre-check ran first and StartTrip returns `{ trip:{ id, status:STARTED },
+ *    workflow_id }` with `workflow_id === trip.id`.
+ *  - The gateway auth: a StartTrip with NO / an INVALID token is rejected as
+ *    `Code.Unauthenticated` by the JWT interceptor (before any pre-check).
+ *  - FleetService is `public`: a direct in-process call needs no token.
  *
- * The split (microservices) topology is config-only here (see k8s/ and istio/);
- * it shares this exact handler code, selected by the `SERVICES` env.
+ * The happy-path billing side effects (openTab → addCharge → settle and
+ * compensation) are now owned by the Temporal saga and are asserted in the
+ * workflow test (orchestration order) and the activity test (real
+ * tabCount/charge + idempotency) — NOT here, since they no longer run
+ * synchronously inside StartTrip.
  */
 
 import assert from "node:assert/strict";
-import { after, before, beforeEach, describe, it } from "node:test";
+import { after, before, describe, it } from "node:test";
 import { create } from "@bufbuild/protobuf";
+import type { Client } from "@connectrpc/connect";
 import { Code, ConnectError, createClient } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
-import type { Client } from "@connectrpc/connect";
-import type { Server } from "@connectum/core";
 import { createTestJwt, TEST_JWT_SECRET } from "@connectum/auth/testing";
+import type { Server } from "@connectum/core";
+import { JWT_ISSUER } from "#auth.ts";
 import { BillingService } from "#gen/billing/v1/billing_pb.ts";
 import { FleetService } from "#gen/fleet/v1/fleet_pb.ts";
-import { StartTripRequestSchema, TripService } from "#gen/trips/v1/trips_pb.ts";
-import { JWT_ISSUER } from "#auth.ts";
+import { GetTripRequestSchema, StartTripRequestSchema, TripService } from "#gen/trips/v1/trips_pb.ts";
 import { buildServer } from "#server.ts";
-import { resetTabs, tabCount } from "#services/billingService.ts";
+import type { TripWorkflowClient, TripWorkflowHandle } from "#services/tripService.ts";
 import { resolveTopology } from "#topology.ts";
 import { makeTestDb } from "../helpers/db.ts";
 
-describe("E2E: car-sharing monolith (in-process gateway, no cluster)", () => {
+/** A recorded `start` call (workflow type + the workflow id used). */
+interface StartCall {
+    workflowType: string;
+    workflowId: string;
+}
+
+/** How a stub handle answers GetTrip: a live query result, or a closed describe(). */
+interface StubHandleBehaviour {
+    /** Status the live Query returns; if `undefined`, the Query throws (closed run). */
+    readonly queryStatus?: string;
+    /** Workflow status name returned by describe() when the Query is rejected. */
+    readonly describeStatusName?: string;
+}
+
+/**
+ * A stub Temporal client that records `start` calls and answers `getHandle`
+ * queries from `handleBehaviour` — so both StartTrip AND GetTrip run with NO
+ * live Temporal. The query/describe SHAPE the real client exposes is reproduced
+ * so the handler's mapping (live Query → status, rejected Query → describe()
+ * fallback) is validated at the RPC boundary.
+ */
+function makeStubWorkflowClient(starts: StartCall[], handleBehaviour: () => StubHandleBehaviour): TripWorkflowClient {
+    return {
+        async start(workflowType, options) {
+            starts.push({ workflowType, workflowId: options.workflowId });
+            return { workflowId: options.workflowId };
+        },
+        getHandle(): TripWorkflowHandle {
+            const behaviour = handleBehaviour();
+            return {
+                async query<Ret>(): Promise<Ret> {
+                    if (behaviour.queryStatus === undefined) {
+                        throw new Error("query not supported on a closed workflow");
+                    }
+                    return behaviour.queryStatus as Ret;
+                },
+                async describe() {
+                    return { status: { name: behaviour.describeStatusName ?? "RUNNING" } };
+                },
+            };
+        },
+    };
+}
+
+describe("E2E: car-sharing monolith (in-process gateway, no cluster, stub Temporal)", () => {
     let server: Server;
     let trips: Client<typeof TripService>;
     let userToken: string;
+    const starts: StartCall[] = [];
+    // Mutated per GetTrip test to drive the stub handle's query/describe answers.
+    let handleBehaviour: StubHandleBehaviour = { queryStatus: "STARTED" };
 
     before(async () => {
         // Force monolith topology so fleet, trips and billing are all mounted
         // locally and ctx.call routes in-process. Inject the shared test secret
-        // so the JWT interceptor verifies tokens minted below, and a
-        // PGlite-backed Drizzle db so FleetService persists without Docker (the
-        // trip handler's in-process ctx.call to GetVehicle reads from it).
+        // so the JWT interceptor verifies tokens minted below, a PGlite-backed
+        // Drizzle db so FleetService persists without Docker, and a STUB Temporal
+        // client so StartTrip's success path AND GetTrip run without a live
+        // Temporal.
         const topology = resolveTopology("*");
         const db = await makeTestDb();
-        server = buildServer({ port: 0, topology, jwtSecret: TEST_JWT_SECRET, db });
+        server = buildServer({ port: 0, topology, jwtSecret: TEST_JWT_SECRET, db, workflowClient: makeStubWorkflowClient(starts, () => handleBehaviour) });
         await server.start();
         const port = server.address?.port ?? 0;
 
-        // Bearer token over the gRPC client maps to gRPC metadata; the JWT
-        // interceptor reads the Authorization header from it.
         userToken = await createTestJwt({ sub: "user-42", name: "Dana" }, { issuer: JWT_ISSUER });
-
         trips = createClient(TripService, createGrpcTransport({ baseUrl: `http://localhost:${port}` }));
-    });
-
-    beforeEach(() => {
-        resetTabs();
     });
 
     after(async () => {
@@ -78,64 +121,105 @@ describe("E2E: car-sharing monolith (in-process gateway, no cluster)", () => {
         assert.equal(server.hasService(BillingService), true);
     });
 
-    it("StartTrip (authenticated): ctx.call checks fleet availability and opens a billing tab", async () => {
-        assert.equal(tabCount(), 0);
+    it("StartTrip (authenticated): pre-checks fleet availability then STARTS the workflow", async () => {
+        const before = starts.length;
 
         const res = await trips.startTrip(create(StartTripRequestSchema, { userId: "user-42", vehicleId: "v-001" }), {
             headers: { Authorization: `Bearer ${userToken}` },
         });
 
+        // The synchronous response carries the trip id, the STARTED status, and
+        // the workflow id (== the trip id).
         assert.equal(res.trip?.status, "STARTED");
         assert.ok(res.trip?.id.startsWith("trip-"));
+        assert.equal(res.workflowId, res.trip?.id);
 
-        // The trip handler's second ctx.call (to the public BillingService) ran
-        // through the same interceptor chain with no Authorization header and
-        // recorded exactly one open tab.
-        assert.equal(tabCount(), 1);
+        // Exactly one workflow was started, of the right type, keyed by trip id.
+        assert.equal(starts.length, before + 1);
+        const started = starts[starts.length - 1];
+        assert.equal(started?.workflowType, "TripWorkflow");
+        assert.equal(started?.workflowId, res.trip?.id);
     });
 
-    it("StartTrip with an UNAVAILABLE vehicle is rejected as FailedPrecondition (no tab opened)", async () => {
+    it("GetTrip (authenticated): reads LIVE status from the workflow Query", async () => {
+        handleBehaviour = { queryStatus: "ENDED" };
+        const res = await trips.getTrip(create(GetTripRequestSchema, { tripId: "trip-live" }), {
+            headers: { Authorization: `Bearer ${userToken}` },
+        });
+        assert.equal(res.trip?.id, "trip-live");
+        // The handler maps the live Query result straight through.
+        assert.equal(res.trip?.status, "ENDED");
+    });
+
+    it("GetTrip falls back to a terminal status via describe() when the workflow has CLOSED", async () => {
+        // queryStatus undefined → the stub Query throws (queries are rejected on
+        // a closed run); the handler falls back to describe(): COMPLETED → SETTLED.
+        handleBehaviour = { describeStatusName: "COMPLETED" };
+        const settled = await trips.getTrip(create(GetTripRequestSchema, { tripId: "trip-done" }), {
+            headers: { Authorization: `Bearer ${userToken}` },
+        });
+        assert.equal(settled.trip?.status, "SETTLED");
+
+        // A failed/cancelled closed run maps to CANCELLED.
+        handleBehaviour = { describeStatusName: "FAILED" };
+        const cancelled = await trips.getTrip(create(GetTripRequestSchema, { tripId: "trip-failed" }), {
+            headers: { Authorization: `Bearer ${userToken}` },
+        });
+        assert.equal(cancelled.trip?.status, "CANCELLED");
+    });
+
+    it("gateway auth: GetTrip with NO token is rejected as Unauthenticated", async () => {
         await assert.rejects(
+            trips.getTrip(create(GetTripRequestSchema, { tripId: "trip-live" })),
+            (err: unknown) => err instanceof ConnectError && err.code === Code.Unauthenticated,
+        );
+    });
+
+    it("StartTrip with an UNAVAILABLE vehicle is FailedPrecondition BEFORE the workflow starts", async () => {
+        const before = starts.length;
+        await assert.rejects(
+            // v-003 is maintenance in the seed.
             trips.startTrip(create(StartTripRequestSchema, { userId: "user-42", vehicleId: "v-003" }), {
                 headers: { Authorization: `Bearer ${userToken}` },
             }),
             (err: unknown) => err instanceof ConnectError && err.code === Code.FailedPrecondition,
         );
-        // The guard fires before the billing call, so no tab is opened.
-        assert.equal(tabCount(), 0);
+        // The pre-check fired before the workflow start — no workflow started.
+        assert.equal(starts.length, before);
     });
 
-    it("StartTrip with an UNKNOWN vehicle surfaces Code.NotFound over the gRPC client", async () => {
-        // The fleet's NotFound travels back through TripService's ctx.call and
-        // out to the external gRPC client. The framework strips the in-process
-        // framing headers, so the client sees a clean Code.NotFound rather than
-        // an HTTP/2 trailer (protocol) error.
+    it("StartTrip with an UNKNOWN vehicle surfaces Code.NotFound BEFORE the workflow starts", async () => {
+        // The fleet's NotFound travels back through TripService's pre-check
+        // ctx.call and out to the external gRPC client.
+        const before = starts.length;
         await assert.rejects(
             trips.startTrip(create(StartTripRequestSchema, { userId: "user-42", vehicleId: "ghost" }), {
                 headers: { Authorization: `Bearer ${userToken}` },
             }),
             (err: unknown) => err instanceof ConnectError && err.code === Code.NotFound,
         );
-        assert.equal(tabCount(), 0);
+        assert.equal(starts.length, before);
     });
 
     it("gateway auth: StartTrip with NO token is rejected as Unauthenticated", async () => {
+        const before = starts.length;
         await assert.rejects(
             trips.startTrip(create(StartTripRequestSchema, { userId: "user-42", vehicleId: "v-001" })),
             (err: unknown) => err instanceof ConnectError && err.code === Code.Unauthenticated,
         );
-        // No handler ran, so no tab was opened.
-        assert.equal(tabCount(), 0);
+        // No handler ran, so no workflow started.
+        assert.equal(starts.length, before);
     });
 
     it("gateway auth: StartTrip with an INVALID token is rejected as Unauthenticated", async () => {
+        const before = starts.length;
         await assert.rejects(
             trips.startTrip(create(StartTripRequestSchema, { userId: "user-42", vehicleId: "v-001" }), {
                 headers: { Authorization: "Bearer not.a.jwt" },
             }),
             (err: unknown) => err instanceof ConnectError && err.code === Code.Unauthenticated,
         );
-        assert.equal(tabCount(), 0);
+        assert.equal(starts.length, before);
     });
 
     it("internal FleetService is public: a direct in-process GetVehicle needs no token", async () => {

--- a/car-sharing/tests/workflow/tripWorkflow.test.ts
+++ b/car-sharing/tests/workflow/tripWorkflow.test.ts
@@ -1,0 +1,154 @@
+/**
+ * TripWorkflow orchestration + compensation tests — DOCKERLESS.
+ *
+ * Uses Temporal's time-skipping test environment (an EMBEDDED test server — no
+ * Docker; the server binary is downloaded + cached on first run only) with a
+ * worker whose ACTIVITIES ARE MOCKED (plain JS functions that record their call
+ * order). The WORKFLOW is the real `TripWorkflow`, so this asserts the saga's
+ * orchestration without any Connectum server or Temporal cluster:
+ *
+ *  - success: forward order is reserveVehicle → recordTrip → endTrip → openTab
+ *    → addCharge → settle.
+ *  - settle fails: the recorded tail unwinds in LIFO order —
+ *    refundCharge → voidTab → markTripCancelled → releaseVehicle.
+ *  - endTrip fails: only the 2→1 compensations run —
+ *    markTripCancelled → releaseVehicle (no billing comps, since steps 5–7
+ *    never ran).
+ *  - reserve fails (non-retryable): fails fast with NO compensation.
+ *
+ * Time-skipping resolves the workflow's "drive" timer instantly. Failures are
+ * forced by making the MOCK throw `ApplicationFailure.nonRetryable`, so the
+ * production retry policy stays realistic (this test does not depend on
+ * `maximumAttempts`).
+ *
+ * @module tests/workflow/tripWorkflow
+ */
+
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { ApplicationFailure } from "@temporalio/activity";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+import * as realActivities from "#temporal/activities.ts";
+import type { TripWorkflowInput } from "#temporal/workflows.ts";
+import { TripWorkflow } from "#temporal/workflows.ts";
+
+/** The workflow bundle source — the same `.ts` the production worker bundles. */
+const WORKFLOWS_PATH = fileURLToPath(new URL("../../src/temporal/workflows.ts", import.meta.url));
+
+const TASK_QUEUE = "test-trip-saga";
+const INPUT: TripWorkflowInput = { userId: "user-42", vehicleId: "v-001", tripId: "trip-test-1" };
+
+/** Build a mock activity set that records call order into `calls`. */
+function makeMockActivities(calls: string[], failing?: { step: string }): Record<string, (...args: unknown[]) => Promise<unknown>> {
+    const record = (name: string, result: unknown = undefined) => {
+        calls.push(name);
+        if (failing?.step === name) {
+            // Non-retryable so the run fails immediately without depending on
+            // the production retry budget.
+            throw ApplicationFailure.create({ message: `mock ${name} failed`, type: "MockFailure", nonRetryable: true });
+        }
+        return result;
+    };
+    return {
+        reserveVehicle: async () => record("reserveVehicle"),
+        releaseVehicle: async () => record("releaseVehicle"),
+        recordTrip: async () => record("recordTrip"),
+        markTripCancelled: async () => record("markTripCancelled"),
+        endTrip: async () => record("endTrip"),
+        openTab: async () => record("openTab"),
+        voidTab: async () => record("voidTab"),
+        addCharge: async () => record("addCharge", "charge-mock-1"),
+        refundCharge: async () => record("refundCharge"),
+        settle: async () => record("settle"),
+    };
+}
+
+describe("TripWorkflow: orchestration + compensation (time-skipping, mocked activities)", () => {
+    let testEnv: TestWorkflowEnvironment;
+
+    before(async () => {
+        testEnv = await TestWorkflowEnvironment.createTimeSkipping();
+    });
+
+    after(async () => {
+        await testEnv?.teardown();
+    });
+
+    /** Run the workflow once with a worker whose activities are `activities`. */
+    async function runWorkflow(activities: Record<string, (...args: unknown[]) => Promise<unknown>>, workflowId: string): Promise<unknown> {
+        const worker = await Worker.create({
+            connection: testEnv.nativeConnection,
+            taskQueue: TASK_QUEUE,
+            workflowsPath: WORKFLOWS_PATH,
+            activities,
+        });
+        return worker.runUntil(testEnv.client.workflow.execute(TripWorkflow, { args: [INPUT], taskQueue: TASK_QUEUE, workflowId }));
+    }
+
+    it("success: runs the forward steps in order and SETTLES", async () => {
+        const calls: string[] = [];
+        const result = await runWorkflow(makeMockActivities(calls), "wf-success");
+
+        assert.equal(result, "SETTLED");
+        assert.deepEqual(calls, ["reserveVehicle", "recordTrip", "endTrip", "openTab", "addCharge", "settle"]);
+    });
+
+    it("settle fails: compensations run in REVERSE order (refund → void → cancel → release)", async () => {
+        const calls: string[] = [];
+        await assert.rejects(runWorkflow(makeMockActivities(calls, { step: "settle" }), "wf-settle-fail"));
+
+        // Forward path up to and including the failing settle, then the LIFO
+        // unwind of every pushed compensation.
+        assert.deepEqual(calls, [
+            "reserveVehicle",
+            "recordTrip",
+            "endTrip",
+            "openTab",
+            "addCharge",
+            "settle", // throws
+            "refundCharge",
+            "voidTab",
+            "markTripCancelled",
+            "releaseVehicle",
+        ]);
+    });
+
+    it("endTrip fails: only the 2→1 compensations run (cancel trip → release vehicle)", async () => {
+        const calls: string[] = [];
+        await assert.rejects(runWorkflow(makeMockActivities(calls, { step: "endTrip" }), "wf-endtrip-fail"));
+
+        // No billing steps ran, so no billing compensations — just the trip
+        // record and the vehicle reservation unwind, in reverse.
+        assert.deepEqual(calls, ["reserveVehicle", "recordTrip", "endTrip", "markTripCancelled", "releaseVehicle"]);
+    });
+
+    it("reserve fails (non-retryable): fails fast with NO compensation", async () => {
+        const calls: string[] = [];
+        await assert.rejects(runWorkflow(makeMockActivities(calls, { step: "reserveVehicle" }), "wf-reserve-fail"));
+
+        // Nothing was pushed before the failing first step, so nothing unwinds.
+        assert.deepEqual(calls, ["reserveVehicle"]);
+    });
+
+    it("the REAL activities module + real workflowsPath register on a Worker (production startup path)", async () => {
+        // The other tests pass hand-built mock activities; this is the ONLY test
+        // that exercises the exact registration `src/worker.ts` does — the real
+        // activities namespace (its lazy ConnectRPC clients are not built by
+        // Worker.create, which only registers, never invokes) plus the real
+        // workflow bundle. Catches a non-function export or a bundle break that
+        // would otherwise only surface at `node src/worker.ts` startup.
+        const worker = await Worker.create({
+            connection: testEnv.nativeConnection,
+            taskQueue: "test-real-activities",
+            workflowsPath: WORKFLOWS_PATH,
+            activities: realActivities,
+        });
+        assert.ok(worker);
+        // Start and immediately stop so the worker's poll/heartbeat loop is
+        // drained and shut down — a created-but-never-run worker leaks a
+        // background loop and the test process never exits.
+        await worker.runUntil(Promise.resolve());
+    });
+});


### PR DESCRIPTION
## What

Phase 2 of the car-sharing evolution: replace the hand-coded `ctx.call` chain in `StartTrip` with a **Temporal durable saga** — workflow + activities + automatic compensation. Temporal owns durable execution, retries and compensation; Connectum services stay thin typed-RPC limbs that activities call over the network. (Builds on Phase 1's Drizzle-backed FleetService.)

## Architecture

- **`src/worker.ts`** — a separate worker process (`node src/worker.ts`), the **only** importer of `@temporalio/worker` (native `core-bridge`). `@temporalio/client` is pure JS, so the existing `node src/index.ts` roles keep their no-build native-TS run model. The workflow `.ts` is bundled by swc at worker startup (verified — no separate build step).
- **`src/temporal/workflows.ts`** — `TripWorkflow`: forward `reserveVehicle → recordTrip → endTrip → openTab → addCharge → settle`, with a **compensation stack** unwound in reverse on any failure (each compensation isolated; idempotent). `reserveVehicle`'s business failure is a **non-retryable** `ApplicationFailure` (fail fast, no compensation). A `getTripStatus` Query exposes live status.
- **`src/temporal/activities.ts` / `clients.ts`** — each activity is one ConnectRPC call to a role service over the existing `*_ADDR` convention.

## Contract

- **`StartTrip`** = synchronous availability **pre-check** (preserves today's `FAILED_PRECONDITION` / `NOT_FOUND`) → starts the durable `TripWorkflow` → returns `{ trip, workflow_id }`.
- New public **`GetTrip`** reads live status via a Workflow Query, with a `describe()` fallback for closed runs.
- proto (additive, `buf breaking` clean): billing `AddCharge/Settle/VoidTab/RefundCharge`; trips `RecordTrip`/`EndTrip` (method-level `public`) + `GetTrip` + `StartTripResponse.workflow_id`.
- TripService/BillingService stay **in-memory** (durable state lives in Temporal); billing gains an idempotent tabs+charges ledger.

## Tests (dockerless)

- **Workflow test** — asserts the forward order AND the reverse compensation order (`settle` fails → refund → void → cancel → release; `endTrip` fails → cancel → release; `reserve` fails → fast, no compensation) via `TestWorkflowEnvironment` (time-skipping) + mocked activities.
- **Activity test** — RPC wiring + compensation idempotency against in-process Connectum services.
- **E2E** — rewritten to the new contract: pre-check error paths + start + GetTrip, with a **lazy** Temporal client so the server runs without a cluster.
- `pnpm typecheck` exit 0; `pnpm test` **36/36**; `buf generate/lint/breaking` exit 0.

## Verification note (honest scope)

The production `@temporalio/client` adapter's types were verified against the installed SDK `.d.ts` (`Connection.lazy`, `WorkflowClient.start/getHandle`, `WorkflowHandle.query/describe → status.name`). The **live-cluster** path (real client → server → worker → real activities against a running Temporal) is **not** exercised by the automated suite — tests use a stub client + the embedded time-skipping server with mocked activities. The `docker-compose.yml` Temporal stack (server + UI + its own Postgres + worker, `mono`/`saga` profiles) is **config-only**, the same convention as Phase 1's k8s/istio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3