### PR TITLE
docs(examples): drop internal ADR-NNN citations from example code comments

### DIFF
--- a/car-sharing/src/db/schema.ts
+++ b/car-sharing/src/db/schema.ts
@@ -16,7 +16,7 @@
 import { boolean, doublePrecision, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
 /**
- * Vehicle lifecycle states. A `const` object (ADR-001: no `enum`) — the string
+ * Vehicle lifecycle states. A `const` object (no `enum` under erasable TypeScript) — the string
  * domain stored in {@link vehicles}.`status`.
  */
 export const VehicleStatus = {

--- a/car-sharing/src/server.ts
+++ b/car-sharing/src/server.ts
@@ -5,8 +5,8 @@
  * What stays constant across topologies:
  *  - the same three service definitions are passed to `createServer`;
  *  - the same generated `serviceCatalog` types and routes every `ctx.call`;
- *  - the same gateway interceptor chain in ADR-024 order (errorHandler → JWT
- *    auth → proto authz → OTel → validation). The chain is uniform; per-method
+ *  - the same gateway interceptor chain in the recommended fixed order
+ *    (errorHandler → JWT auth → proto authz → OTel → validation). The chain is uniform; per-method
  *    behaviour comes from proto annotations (fleet/billing are `public`,
  *    TripService requires auth).
  *
@@ -149,7 +149,7 @@ export function buildServer(options: BuildServerOptions = {}): Server {
 
     const otelInterceptor = buildOtelInterceptor();
     const interceptors: Interceptor[] = [
-        // ADR-024 chain order: errorHandler first, then auth/authz immediately
+        // Fixed chain order: errorHandler first, then auth/authz immediately
         // after it (so unauthenticated requests are rejected before validation),
         // then OTel — placed after authz so getAuthContext() is populated for
         // enduser span attributes — then the default validation chain.

--- a/car-sharing/src/temporal/tripStatus.ts
+++ b/car-sharing/src/temporal/tripStatus.ts
@@ -11,7 +11,7 @@
  *
  * The status is a plain string on the wire (no proto enum — the example's
  * `erasableSyntaxOnly` tsconfig rejects the native `enum` protoc-gen-es emits),
- * with the domain pinned by this `const` object (ADR-001: no `enum`).
+ * with the domain pinned by this `const` object.
  *
  * @module temporal/tripStatus
  */

--- a/hris/src/db/schema.ts
+++ b/hris/src/db/schema.ts
@@ -21,7 +21,7 @@
 import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
 /**
- * Employment lifecycle states. A `const` object (ADR-001: no `enum`) — the
+ * Employment lifecycle states. A `const` object (no `enum` under erasable TypeScript) — the
  * string domain stored in {@link employees}.`status`.
  */
 export const EmployeeStatus = {


### PR DESCRIPTION
## What

Example source should be self-explanatory. Internal **ADR-NNN** numbers cited in code comments are jargon a reader copying the example cannot resolve — removed them, keeping the rationale in plain words.

- `car-sharing/src/server.ts` — "ADR-024 order" → "recommended / fixed order"
- `car-sharing/src/temporal/tripStatus.ts`, `car-sharing/src/db/schema.ts`, `hris/src/db/schema.ts` — "(ADR-001: no enum)" → plain "(no enum under erasable TypeScript)", or dropped where the reason is already stated in the surrounding comment.

Comment-only; no code behavior changes. The architectural rationale still lives in the ADR pages, not in example code.

(The matching docs-site fixes are in docs PR #52; the `hris` onboarding-saga `onboardingStatus.ts` carries the same fix on its own branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdeH7fExPmiRHRirGuvGk3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation and comments to improve code clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->