### PR TITLE
docs(car-sharing): refresh stale 1.1.0 forward-references (now released)

### DIFF
--- a/car-sharing/README.md
+++ b/car-sharing/README.md
@@ -443,10 +443,11 @@ The committed `openapi/*.yaml` is the showcase output — regenerate with
 `pnpm openapi` after changing the proto or its auth options.
 
 > **Notes.** Streaming RPCs (`ListVehicles`) are omitted from the base spec
-> unless the plugin's `with-streaming` opt is set. The overlay works on the
-> published `@connectum/auth` 1.0.0; once 1.1.0 is out, methods marked
-> `internal` in the proto also get `x-internal: true` (the resolver then
-> exposes that marker).
+> unless the plugin's `with-streaming` opt is set. The overlay targets the
+> `@connectum/auth` 1.0.0 API this example pins. `@connectum/auth` 1.1.0 adds an
+> `internal` method marker that the resolver exposes as `x-internal: true`;
+> migrating this example onto that marker is tracked in
+> [examples#36](https://github.com/Connectum-Framework/examples/issues/36).
 
 ## Build the image
 

--- a/car-sharing/scripts/openapi-authz.ts
+++ b/car-sharing/scripts/openapi-authz.ts
@@ -10,8 +10,9 @@
 // Run via `pnpm openapi` (generates the base from buf.gen.openapi.yaml, then this
 // overlay). NOTE: streaming RPCs (e.g. ListVehicles) are omitted from the base
 // unless the plugin's `with-streaming` opt is set, so they get no operation here.
-// A method marked `internal` (1.1.0) would also add `x-internal: true` once the
-// resolver exposes that field.
+// `@connectum/auth` 1.1.0 adds an `internal` method marker; this example targets
+// the 1.0.0 API (no `internal` field on the resolver), so only `public` is mapped.
+// On 1.1.0 a method marked `internal` would also add `x-internal: true`.
 
 import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -60,7 +61,8 @@ for (const { svc, file } of SPECS) {
         op.security = [{ bearerAuth: [] }];
         if (auth.requires && auth.requires.roles.length > 0) op["x-connectum-required-roles"] = [...auth.requires.roles];
         if (auth.requires && auth.requires.scopes.length > 0) op["x-connectum-required-scopes"] = [...auth.requires.scopes];
-        // A method marked `internal` (1.1.0) would add `op["x-internal"] = true` here.
+        // On `@connectum/auth` 1.1.0, a method marked `internal` would add
+        // `op["x-internal"] = true` here (this example targets 1.0.0, so it does not).
         securedCount += 1;
     }
 


### PR DESCRIPTION
1.1.0 is published, so the "once 1.1.0 is out" forward-references in car-sharing no longer read true. This example still pins `@connectum/auth` `^1.0.0` (which resolves to 1.0.0) and keeps the `public` workaround, so the notes are reworded to present tense and the `internal`-marker migration is pointed at the tracking issue.

- **README**: the OpenAPI overlay note now states 1.1.0 adds the `internal` marker and links the migration to #36 (instead of "once 1.1.0 is out").
- **scripts/openapi-authz.ts**: the two `internal`-marker comments become present-tense (this example targets the 1.0.0 API; on 1.1.0 a method marked `internal` would add `x-internal: true`).

Prose/comments only — no behavior change. The "resolves to the 1.0.0 versions" statement is left intact (it is correct: `^1.0.0` resolves to 1.0.0).

Part of #36.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified OpenAPI guidance for `@connectum/auth` so the notes now distinguish between v1.0.0 and v1.1.0 behavior.
  * Added clearer mention of the new `internal` method marker and its OpenAPI representation.
  * Updated the example reference to point to the current migration/tracking item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->