### PR TITLE
fix(getting-started): chain `buf generate` into typecheck/test/start

### DIFF
--- a/getting-started/package.json
+++ b/getting-started/package.json
@@ -9,16 +9,16 @@
     "#*": "./src/*"
   },
   "scripts": {
-    "start": "node src/index.ts",
+    "start": "buf generate && node src/index.ts",
     "dev": "node --watch src/index.ts",
-    "start:bun": "bun src/index.ts",
-    "start:tsx": "tsx src/index.ts",
-    "typecheck": "tsc --noEmit",
+    "start:bun": "buf generate && bun src/index.ts",
+    "start:tsx": "buf generate && tsx src/index.ts",
+    "typecheck": "buf generate && tsc --noEmit",
     "buf:generate": "buf generate",
     "buf:lint": "buf lint",
     "build:proto": "pnpm run buf:generate",
-    "test": "node --test tests/**/*.test.ts",
-    "test:bun": "bun test tests/"
+    "test": "buf generate && node --test tests/**/*.test.ts",
+    "test:bun": "buf generate && bun test tests/"
   },
   "keywords": [
     "connectrpc",


### PR DESCRIPTION
## Summary

`getting-started` is the example users clone/degit directly, and it is also the base the new `connectum init` fetches. Its `gen/` directory is gitignored, so a fresh clone previously failed with an unresolved `#gen/...` import until `buf generate` was run by hand — an error message that names neither `buf` nor the fix.

## Change

Chain `buf generate` into the scripts that consume generated code:

| Script | Before | After |
|--------|--------|-------|
| `start` | `node src/index.ts` | `buf generate && node src/index.ts` |
| `typecheck` | `tsc --noEmit` | `buf generate && tsc --noEmit` |
| `test` | `node --test tests/**/*.test.ts` | `buf generate && node --test tests/**/*.test.ts` |

(`start:bun`, `start:tsx` and `test:bun` get the same prefix; `dev` is unchanged since it watches `src`.)

This is deliberately **not** a pnpm `pre*` hook — those silently no-op when `enable-pre-post-scripts` is off. It matches exactly what `connectum init` bakes into scaffolded projects, so a scaffolded project and a directly-cloned `getting-started` behave the same.

## Scope

Only `getting-started` is changed here — it is the direct degit / scaffold base. The broader `examples/*` sweep (with-events-*, hris, car-sharing, …) is a follow-up: those run inside the pnpm monorepo where `gen/` is already built, so the fix is consistency-only there.

Companion to the framework PR adding `connectum init` / `connectum generate service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdapMMJeamn5TDrY8yzHRQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service, development, testing, and type-checking commands to generate required code automatically before execution.
  * Existing protocol-generation, linting, and build commands remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->